### PR TITLE
Optional direct linkage to Intel MKL with fine-grained multithreading control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,27 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
   
+  linux-build-mkl:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install and Test
+        run: ./.github/workflows/run_ci_mkl.sh
+      - name: Upload to codecov
+        if: matrix.python-version == '3.8'
+        uses: codecov/codecov-action@v1.0.13
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+  
   linux-build-aarch64:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   linux-build-mkl:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04]
         python-version: ["3.12"]

--- a/.github/workflows/ci_linux_mkl/build_pyscf.sh
+++ b/.github/workflows/ci_linux_mkl/build_pyscf.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd ./pyscf/lib
+curl -L "https://github.com/pyscf/pyscf-build-deps/blob/master/pyscf-2.4a-deps.tar.gz?raw=true" | tar xzf -
+mkdir build; cd build
+cmake -DUSE_MKL=ON -DBUILD_LIBXC=OFF -DBUILD_XCFUN=ON -DBUILD_LIBCINT=OFF -DXCFUN_MAX_ORDER=4 ..
+make -j4
+cd ..
+rm -Rf build
+cd ../..

--- a/.github/workflows/ci_linux_mkl/deps_apt.sh
+++ b/.github/workflows/ci_linux_mkl/deps_apt.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+sudo apt-get -qq install \
+    gcc \
+    libblas-dev \
+    cmake \
+    curl

--- a/.github/workflows/ci_linux_mkl/python_deps.sh
+++ b/.github/workflows/ci_linux_mkl/python_deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+python -m pip install --upgrade pip
+pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer
+pip install mkl mkl-devel mkl-include
+pip install pyberny
+pip install --no-deps pyscf-dispersion
+
+version=$(python -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version))')
+if [ $version != '3.12' ]; then
+    pip install geometric
+    pip install spglib
+fi
+
+#cppe
+if [ "$RUNNER_OS" == "Linux" ] && [ $version != "3.12" ]; then
+    pip install cppe
+fi

--- a/.github/workflows/run_ci_mkl.sh
+++ b/.github/workflows/run_ci_mkl.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$RUNNER_OS" == "Linux" ]; then
+    os='linux'
+elif [ "$RUNNER_OS" == "macOS" ]; then
+    os='macos'
+else
+    echo "$RUNNER_OS not supported"
+    exit 1
+fi
+
+./.github/workflows/ci_"$os"_mkl/deps_apt.sh
+./.github/workflows/ci_"$os"_mkl/python_deps.sh
+./.github/workflows/ci_"$os"_mkl/build_pyscf.sh
+./.github/workflows/run_tests.sh

--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -66,17 +66,39 @@ if(EXISTS "${PROJECT_SOURCE_DIR}/cmake.arch.inc")
   include("${PROJECT_SOURCE_DIR}/cmake.arch.inc")
 endif()
 
-if (NOT BLAS_LIBRARIES)
-#enable_language(Fortran)
-find_package(BLAS)
-check_function_exists(ffsll HAVE_FFS)
-endif()
+option(USE_MKL, "Use Intel MKL API and headers" OFF)
 
-if (NOT BLAS_LIBRARIES)
-  message(FATAL_ERROR "A required library with BLAS API not found.")
+if(USE_MKL)
+  # Finer threading control is available thanks to
+  # MKL threading control support functions, so it's okay
+  # not to use sequential BLAS.
+  if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
+    set(MKL_THREADING "intel_thread")
+  elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(MKL_THREADING "gnu_thread")
+  endif()
+  set(MKL_INTERFACE "lp64")
+  find_package(MKL CONFIG REQUIRED)
+  if(NOT MKL_FOUND)
+    message(FATAL_ERROR "MKLConfig.cmake not found. Make sure CMake can find it.")
+  endif()
+  set(BLAS_LIBRARIES MKL::MKL)
+  add_compile_definitions(PYSCF_USE_MKL)
 else()
-  message(STATUS "BLAS libraries: ${BLAS_LIBRARIES}")
-endif()
+  # If MKL is not used, try to find BLAS.
+  if (NOT BLAS_LIBRARIES)
+  #enable_language(Fortran)
+  find_package(BLAS)
+  check_function_exists(ffsll HAVE_FFS)
+  endif()
+
+  if (NOT BLAS_LIBRARIES)
+    message(FATAL_ERROR "A required library with BLAS API not found.")
+  else()
+    message(STATUS "BLAS libraries: ${BLAS_LIBRARIES}")
+  endif()
+endif() # USE_MKL
+
 # if unable to find mkl library, just create BLAS_LIBRARIES here, e.g.
 # set(BLAS_LIBRARIES "-L/path/to/mkl/lib -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lmkl_avx -lm")
 # or

--- a/pyscf/lib/agf2/uagf2.c
+++ b/pyscf/lib/agf2/uagf2.c
@@ -28,7 +28,7 @@
 #include "config.h"
 #include "vhf/fblas.h"
 #include "ragf2.h"
-
+#include "np_helper/np_helper.h"
 
 
 /*
@@ -68,15 +68,19 @@ void AGF2uee_vv_vev_islice(double *xija,
 
 #pragma omp parallel
 {
-    double *eja = calloc(noa*nva, sizeof(double));
-    double *eJA = calloc(nob*nvb, sizeof(double));
-    double *xia = calloc(nmo*noa*nva, sizeof(double));
-    double *xja = calloc(nmo*noa*nva, sizeof(double));
-    double *xJA = calloc(nmo*nob*nvb, sizeof(double));
-    double *exJA = calloc(nmo*nob*nvb, sizeof(double));
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
 
-    double *vv_priv = calloc(nmo*nmo, sizeof(double));
-    double *vev_priv = calloc(nmo*nmo, sizeof(double));
+    double *eja = pyscf_calloc(noa*nva, sizeof(double));
+    double *eJA = pyscf_calloc(nob*nvb, sizeof(double));
+    double *xia = pyscf_calloc(nmo*noa*nva, sizeof(double));
+    double *xja = pyscf_calloc(nmo*noa*nva, sizeof(double));
+    double *xJA = pyscf_calloc(nmo*nob*nvb, sizeof(double));
+    double *exJA = pyscf_calloc(nmo*nob*nvb, sizeof(double));
+
+    double *vv_priv = pyscf_calloc(nmo*nmo, sizeof(double));
+    double *vev_priv = pyscf_calloc(nmo*nmo, sizeof(double));
 
     int i;
 
@@ -119,12 +123,12 @@ void AGF2uee_vv_vev_islice(double *xija,
         dgemm_(&TRANS_T, &TRANS_N, &nmo, &nmo, &nJA, &os_factor, xJA, &nJA, exJA, &nJA, &D1, vev_priv, &nmo);
     }
 
-    free(eja);
-    free(eJA);
-    free(xia);
-    free(xja);
-    free(xJA);
-    free(exJA);
+    pyscf_free(eja);
+    pyscf_free(eJA);
+    pyscf_free(xia);
+    pyscf_free(xja);
+    pyscf_free(xJA);
+    pyscf_free(exJA);
 
 #pragma omp critical
     for (i = 0; i < (nmo*nmo); i++) {
@@ -132,8 +136,12 @@ void AGF2uee_vv_vev_islice(double *xija,
         vev[i] += vev_priv[i];
     }
 
-    free(vv_priv);
-    free(vev_priv);
+    pyscf_free(vv_priv);
+    pyscf_free(vev_priv);
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -175,17 +183,21 @@ void AGF2udf_vv_vev_islice(double *qxi,
 
 #pragma omp parallel
 {
-    double *qa = calloc(naux*nva, sizeof(double));
-    double *qx = calloc(naux*nmo, sizeof(double));
-    double *eja = calloc(noa*nva, sizeof(double));
-    double *eJA = calloc(nob*nvb, sizeof(double));
-    double *xia = calloc(nmo*noa*nva, sizeof(double));
-    double *xja = calloc(nmo*noa*nva, sizeof(double));
-    double *xJA = calloc(nmo*nob*nvb, sizeof(double));
-    double *exJA = calloc(nmo*nob*nvb, sizeof(double));
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
 
-    double *vv_priv = calloc(nmo*nmo, sizeof(double));
-    double *vev_priv = calloc(nmo*nmo, sizeof(double));
+    double *qa = pyscf_calloc(naux*nva, sizeof(double));
+    double *qx = pyscf_calloc(naux*nmo, sizeof(double));
+    double *eja = pyscf_calloc(noa*nva, sizeof(double));
+    double *eJA = pyscf_calloc(nob*nvb, sizeof(double));
+    double *xia = pyscf_calloc(nmo*noa*nva, sizeof(double));
+    double *xja = pyscf_calloc(nmo*noa*nva, sizeof(double));
+    double *xJA = pyscf_calloc(nmo*nob*nvb, sizeof(double));
+    double *exJA = pyscf_calloc(nmo*nob*nvb, sizeof(double));
+
+    double *vv_priv = pyscf_calloc(nmo*nmo, sizeof(double));
+    double *vev_priv = pyscf_calloc(nmo*nmo, sizeof(double));
 
     int i;
 
@@ -234,14 +246,14 @@ void AGF2udf_vv_vev_islice(double *qxi,
         dgemm_(&TRANS_T, &TRANS_N, &nmo, &nmo, &nJA, &os_factor, xJA, &nJA, exJA, &nJA, &D1, vev_priv, &nmo);
     }
 
-    free(qa);
-    free(qx);
-    free(eja);
-    free(eJA);
-    free(xia);
-    free(xja);
-    free(xJA);
-    free(exJA);
+    pyscf_free(qa);
+    pyscf_free(qx);
+    pyscf_free(eja);
+    pyscf_free(eJA);
+    pyscf_free(xia);
+    pyscf_free(xja);
+    pyscf_free(xJA);
+    pyscf_free(exJA);
 
 #pragma omp critical
     for (i = 0; i < (nmo*nmo); i++) {
@@ -249,8 +261,12 @@ void AGF2udf_vv_vev_islice(double *qxi,
         vev[i] += vev_priv[i];
     }
 
-    free(vv_priv);
-    free(vev_priv);
+    pyscf_free(vv_priv);
+    pyscf_free(vev_priv);
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -287,22 +303,26 @@ void AGF2udf_vv_vev_islice_lowmem(double *qxi,
 
 #pragma omp parallel
 {
-    double *qx_i = calloc(naux*nmo, sizeof(double));
-    double *qx_j = calloc(naux*nmo, sizeof(double));
-    double *qa_i = calloc(naux*nva, sizeof(double));
-    double *qa_j = calloc(naux*nva, sizeof(double));
-    double *qA_i = calloc(naux*nvb, sizeof(double));
-    double *qA_j = calloc(naux*nvb, sizeof(double));
-    double *xa_i = calloc(nmo*nva, sizeof(double));
-    double *xa_j = calloc(nmo*nva, sizeof(double));
-    double *xA_i = calloc(nmo*nvb, sizeof(double));
-    double *xA_j = calloc(nmo*nvb, sizeof(double));
-    double *ea = calloc(nva, sizeof(double));
-    double *eA = calloc(nvb, sizeof(double));
-    double *exA_i = calloc(nmo*nvb, sizeof(double));
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
 
-    double *vv_priv = calloc(nmo*nmo, sizeof(double));
-    double *vev_priv = calloc(nmo*nmo, sizeof(double));
+    double *qx_i = pyscf_calloc(naux*nmo, sizeof(double));
+    double *qx_j = pyscf_calloc(naux*nmo, sizeof(double));
+    double *qa_i = pyscf_calloc(naux*nva, sizeof(double));
+    double *qa_j = pyscf_calloc(naux*nva, sizeof(double));
+    double *qA_i = pyscf_calloc(naux*nvb, sizeof(double));
+    double *qA_j = pyscf_calloc(naux*nvb, sizeof(double));
+    double *xa_i = pyscf_calloc(nmo*nva, sizeof(double));
+    double *xa_j = pyscf_calloc(nmo*nva, sizeof(double));
+    double *xA_i = pyscf_calloc(nmo*nvb, sizeof(double));
+    double *xA_j = pyscf_calloc(nmo*nvb, sizeof(double));
+    double *ea = pyscf_calloc(nva, sizeof(double));
+    double *eA = pyscf_calloc(nvb, sizeof(double));
+    double *exA_i = pyscf_calloc(nmo*nvb, sizeof(double));
+
+    double *vv_priv = pyscf_calloc(nmo*nmo, sizeof(double));
+    double *vev_priv = pyscf_calloc(nmo*nmo, sizeof(double));
 
     bool do_os, do_ss;
     int i, j, ij;
@@ -373,19 +393,19 @@ void AGF2udf_vv_vev_islice_lowmem(double *qxi,
         }
     }
 
-    free(qx_i);
-    free(qx_j);
-    free(qa_i);
-    free(qa_j);
-    free(qA_i);
-    free(qA_j);
-    free(xa_i);
-    free(xa_j);
-    free(xA_i);
-    free(xA_j);
-    free(ea);
-    free(eA);
-    free(exA_i);
+    pyscf_free(qx_i);
+    pyscf_free(qx_j);
+    pyscf_free(qa_i);
+    pyscf_free(qa_j);
+    pyscf_free(qA_i);
+    pyscf_free(qA_j);
+    pyscf_free(xa_i);
+    pyscf_free(xa_j);
+    pyscf_free(xA_i);
+    pyscf_free(xA_j);
+    pyscf_free(ea);
+    pyscf_free(eA);
+    pyscf_free(exA_i);
 
 #pragma omp critical
     for (i = 0; i < (nmo*nmo); i++) {
@@ -393,7 +413,11 @@ void AGF2udf_vv_vev_islice_lowmem(double *qxi,
         vev[i] += vev_priv[i];
     }
 
-    free(vv_priv);
-    free(vev_priv);
+    pyscf_free(vv_priv);
+    pyscf_free(vev_priv);
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
 }

--- a/pyscf/lib/ao2mo/r_ao2mo.c
+++ b/pyscf/lib/ao2mo/r_ao2mo.c
@@ -59,13 +59,13 @@ int AO2MOmmm_r_iltj(double complex *vout, double complex *eri,
         int j_start = envs->ket_start;
         int j_count = envs->ket_count;
         int i;
-        double *buf1 = malloc(sizeof(double)*n2c*i_count*3);
+        double *buf1 = pyscf_malloc(sizeof(double)*n2c*i_count*3);
         double *buf2 = buf1 + n2c*i_count;
         double *buf3 = buf2 + n2c*i_count;
         double *bufr, *bufi;
-        double *mo1 = malloc(sizeof(double) * n2c*MAX(i_count,j_count)*2);
+        double *mo1 = pyscf_malloc(sizeof(double) * n2c*MAX(i_count,j_count)*2);
         double *mo2, *mo_r, *mo_i;
-        double *eri_r = malloc(sizeof(double) * n2c*n2c*3);
+        double *eri_r = pyscf_malloc(sizeof(double) * n2c*n2c*3);
         double *eri_i = eri_r + n2c*n2c;
         double *eri1  = eri_i + n2c*n2c;
         double *vout1, *vout2, *vout3;
@@ -89,7 +89,7 @@ int AO2MOmmm_r_iltj(double complex *vout, double complex *eri,
                &D1, eri_r, &n2c, mo2, &n2c, &D0, buf2, &n2c);
         dgemm_(&TRANS_N, &TRANS_N, &n2c, &i_count, &n2c,
                &D1, eri_i, &n2c, mo1, &n2c, &D0, buf3, &n2c);
-        free(eri_r);
+        pyscf_free(eri_r);
 
         // C_qj^* (iq| = (ij|
         bufr = buf3;
@@ -108,7 +108,7 @@ int AO2MOmmm_r_iltj(double complex *vout, double complex *eri,
                 mo1[i] = mo_r[i] + mo_i[i];
                 mo2[i] = mo_i[i] - mo_r[i];
         }
-        vout1 = malloc(sizeof(double)*i_count*j_count*3);
+        vout1 = pyscf_malloc(sizeof(double)*i_count*j_count*3);
         vout2 = vout1 + i_count * j_count;
         vout3 = vout2 + i_count * j_count;
         dgemm_(&TRANS_T, &TRANS_N, &j_count, &i_count, &n2c,
@@ -120,9 +120,9 @@ int AO2MOmmm_r_iltj(double complex *vout, double complex *eri,
         for (i = 0; i < i_count*j_count; i++) {
                 vout[i] = (vout1[i]-vout3[i]) + (vout1[i]+vout2[i])*_Complex_I;
         }
-        free(vout1);
-        free(buf1);
-        free(mo1);
+        pyscf_free(vout1);
+        pyscf_free(buf1);
+        pyscf_free(mo1);
         return 0;
 }
 int AO2MOmmm_r_s1_iltj(double complex *vout, double complex *eri, 
@@ -153,13 +153,13 @@ int AO2MOmmm_r_igtj(double complex *vout, double complex *eri,
         int j_start = envs->ket_start;
         int j_count = envs->ket_count;
         int i;
-        double *buf1 = malloc(sizeof(double)*n2c*j_count*3);
+        double *buf1 = pyscf_malloc(sizeof(double)*n2c*j_count*3);
         double *buf2 = buf1 + n2c*j_count;
         double *buf3 = buf2 + n2c*j_count;
         double *bufr, *bufi;
-        double *mo1 = malloc(sizeof(double) * n2c*MAX(i_count,j_count)*2);
+        double *mo1 = pyscf_malloc(sizeof(double) * n2c*MAX(i_count,j_count)*2);
         double *mo2, *mo_r, *mo_i;
-        double *eri_r = malloc(sizeof(double) * n2c*n2c*3);
+        double *eri_r = pyscf_malloc(sizeof(double) * n2c*n2c*3);
         double *eri_i = eri_r + n2c*n2c;
         double *eri1  = eri_i + n2c*n2c;
         double *vout1, *vout2, *vout3;
@@ -184,7 +184,7 @@ int AO2MOmmm_r_igtj(double complex *vout, double complex *eri,
                &D1, mo2, &n2c, eri_r, &n2c, &D0, buf2, &j_count);
         dgemm_(&TRANS_T, &TRANS_N, &j_count, &n2c, &n2c,
                &D1, mo1, &n2c, eri_i, &n2c, &D0, buf3, &j_count);
-        free(eri_r);
+        pyscf_free(eri_r);
 
         bufr = buf3;
         bufi = buf2;
@@ -202,7 +202,7 @@ int AO2MOmmm_r_igtj(double complex *vout, double complex *eri,
                 mo1[i] = mo_r[i] - mo_i[i];
                 mo2[i] =-mo_i[i] - mo_r[i];
         }
-        vout1 = malloc(sizeof(double)*i_count*j_count*3);
+        vout1 = pyscf_malloc(sizeof(double)*i_count*j_count*3);
         vout2 = vout1 + i_count * j_count;
         vout3 = vout2 + i_count * j_count;
         dgemm_(&TRANS_N, &TRANS_N, &j_count, &i_count, &n2c,
@@ -214,9 +214,9 @@ int AO2MOmmm_r_igtj(double complex *vout, double complex *eri,
         for (i = 0; i < i_count*j_count; i++) {
                 vout[i] = (vout1[i]-vout3[i]) + (vout1[i]+vout2[i])*_Complex_I;
         }
-        free(vout1);
-        free(buf1);
-        free(mo1);
+        pyscf_free(vout1);
+        pyscf_free(buf1);
+        pyscf_free(mo1);
         return 0;
 }
 int AO2MOmmm_r_s1_igtj(double complex *vout, double complex *eri,
@@ -242,7 +242,7 @@ static void fill_s1(int (*intor)(), int (*fprescreen)(), double complex *eri,
         int kl, jsh, ksh, lsh, dj, dk, dl;
         int icomp, i, j, k, l, n;
         int shls[4];
-        double complex *buf = malloc(sizeof(double complex)
+        double complex *buf = pyscf_malloc(sizeof(double complex)
                                      *di*nao*NCTRMAX*NCTRMAX*envs->ncomp);
         assert(buf);
         double complex *pbuf, *pbuf1, *peri;
@@ -293,7 +293,7 @@ static void fill_s1(int (*intor)(), int (*fprescreen)(), double complex *eri,
                 }
                 eri += nao2 * dk * dl;
         }
-        free(buf);
+        pyscf_free(buf);
 }
 
 static void fill_s2(int (*intor)(), int (*fprescreen)(), double complex *eri,
@@ -308,7 +308,7 @@ static void fill_s2(int (*intor)(), int (*fprescreen)(), double complex *eri,
         int kl, jsh, ksh, lsh, dj, dk, dl;
         int icomp, i, j, k, l, n;
         int shls[4];
-        double complex *buf = malloc(sizeof(double complex)
+        double complex *buf = pyscf_malloc(sizeof(double complex)
                                      *di*nao*nkl*envs->ncomp);
         assert(buf);
         double complex *pbuf, *pbuf1, *peri;
@@ -360,7 +360,7 @@ static void fill_s2(int (*intor)(), int (*fprescreen)(), double complex *eri,
                 }
                 eri += nao2 * dk * dl;
         }
-        free(buf);
+        pyscf_free(buf);
 }
 
 void AO2MOfill_r_s1(int (*intor)(), int (*fprescreen)(),
@@ -566,11 +566,11 @@ void AO2MOtranse1_r_s2ij(int (*fmmm)(),
         int nao = envs->nao;
         size_t ij_pair = (*fmmm)(NULL, NULL, envs, 1);
         size_t nao2 = nao * nao;
-        double complex *buf = malloc(sizeof(double complex) * nao*nao);
+        double complex *buf = pyscf_malloc(sizeof(double complex) * nao*nao);
         copy_mat(buf, vin+nao2*row_id, envs->ao_loc, envs->nbas);
         timerev_mat(buf, envs->tao, envs->ao_loc, envs->nbas);
         (*fmmm)(vout+ij_pair*row_id, buf, envs, 0);
-        free(buf);
+        pyscf_free(buf);
 }
 
 void AO2MOtranse1_r_s2kl(int (*fmmm)(),
@@ -594,11 +594,11 @@ void AO2MOtranse1_r_a2ij(int (*fmmm)(),
         int nao = envs->nao;
         size_t ij_pair = (*fmmm)(NULL, NULL, envs, 1);
         size_t nao2 = nao * nao;
-        double complex *buf = malloc(sizeof(double complex) * nao*nao);
+        double complex *buf = pyscf_malloc(sizeof(double complex) * nao*nao);
         copy_mat(buf, vin+nao2*row_id, envs->ao_loc, envs->nbas);
         atimerev_mat(buf, envs->tao, envs->ao_loc, envs->nbas);
         (*fmmm)(vout+ij_pair*row_id, buf, envs, 0);
-        free(buf);
+        pyscf_free(buf);
 }
 
 void AO2MOtranse1_r_a2kl(int (*fmmm)(),
@@ -655,7 +655,7 @@ void AO2MOsortranse2_r_s1(int (*fmmm)(),
         size_t nao2 = envs->nao * envs->nao;
         int ish, jsh, di, dj;
         int i, j;
-        double complex *buf = malloc(sizeof(double complex) * nao2);
+        double complex *buf = pyscf_malloc(sizeof(double complex) * nao2);
         double complex *pbuf;
 
         vin += nao2 * row_id;
@@ -674,7 +674,7 @@ void AO2MOsortranse2_r_s1(int (*fmmm)(),
 
         (*fmmm)(vout+ij_pair*row_id, buf, envs, 0);
 
-        free(buf);
+        pyscf_free(buf);
 }
 
 void AO2MOsortranse2_r_s2ij(int (*fmmm)(),
@@ -694,7 +694,7 @@ void AO2MOsortranse2_r_s2kl(int (*fmmm)(),
         size_t nao2 = 0;
         int ish, jsh, di, dj;
         int i, j;
-        double complex *buf = malloc(sizeof(double complex) * nao * nao);
+        double complex *buf = pyscf_malloc(sizeof(double complex) * nao * nao);
         double complex *pbuf;
 
         nao2 = nao * (nao+1) / 2;
@@ -720,7 +720,7 @@ void AO2MOsortranse2_r_s2kl(int (*fmmm)(),
         timerev_mat(buf, envs->tao, envs->ao_loc, envs->nbas);
         (*fmmm)(vout+ij_pair*row_id, buf, envs, 0);
 
-        free(buf);
+        pyscf_free(buf);
 }
 
 void AO2MOsortranse2_r_s4(int (*fmmm)(),
@@ -747,7 +747,7 @@ void AO2MOsortranse2_r_a2kl(int (*fmmm)(),
         size_t nao2 = 0;
         int ish, jsh, di, dj;
         int i, j;
-        double complex *buf = malloc(sizeof(double complex) * nao * nao);
+        double complex *buf = pyscf_malloc(sizeof(double complex) * nao * nao);
         double complex *pbuf;
 
         nao2 = nao * (nao+1) / 2;
@@ -773,7 +773,7 @@ void AO2MOsortranse2_r_a2kl(int (*fmmm)(),
         atimerev_mat(buf, envs->tao, envs->ao_loc, envs->nbas);
         (*fmmm)(vout+ij_pair*row_id, buf, envs, 0);
 
-        free(buf);
+        pyscf_free(buf);
 }
 
 // anti-time-reversal between ij and time-reversal between kl
@@ -820,8 +820,8 @@ void AO2MOr_e1_drv(int (*intor)(), void (*fill)(),
         int nao = ao_loc[nbas];
         int nmo = MAX(orbs_slice[1], orbs_slice[3]);
         int i;
-        double *mo_r = malloc(sizeof(double) * nao * nmo);
-        double *mo_i = malloc(sizeof(double) * nao * nmo);
+        double *mo_r = pyscf_malloc(sizeof(double) * nao * nmo);
+        double *mo_i = pyscf_malloc(sizeof(double) * nao * nmo);
         for (i = 0; i < nao*nmo; i++) {
                 mo_r[i] = creal(mo_coeff[i]);
                 mo_i[i] = cimag(mo_coeff[i]);
@@ -832,10 +832,10 @@ void AO2MOr_e1_drv(int (*intor)(), void (*fill)(),
                                   ncomp, tao, ao_loc, mo_coeff,
                                   mo_r, mo_i, cintopt, vhfopt};
 
-        double complex *eri_ao = malloc(sizeof(double complex)
+        double complex *eri_ao = pyscf_malloc(sizeof(double complex)
                                         * nao*nao*nkl*ncomp);
         if (eri_ao == NULL) {
-                fprintf(stderr, "malloc(%zu) failed in AO2MOr_e1_drv\n",
+                fprintf(stderr, "pyscf_malloc(%zu) failed in AO2MOr_e1_drv\n",
                         sizeof(double complex) * nao*nao*nkl*ncomp);
                 exit(1);
         }
@@ -850,22 +850,37 @@ void AO2MOr_e1_drv(int (*intor)(), void (*fill)(),
 #pragma omp parallel default(none) \
         shared(fill, fprescreen, eri_ao, envs, intor, nkl, nbas) \
         private(ish)
+{
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
 #pragma omp for nowait schedule(dynamic)
         for (ish = 0; ish < nbas; ish++) {
                 (*fill)(intor, fprescreen, eri_ao, nkl, ish, &envs, 0);
         }
-
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+}
 #pragma omp parallel default(none) \
         shared(ftrans, fmmm, eri, eri_ao, nkl, ncomp, envs) \
         private(kl)
+{
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
 #pragma omp for nowait schedule(static)
         for (kl = 0; kl < nkl*ncomp; kl++) {
                 (*ftrans)(fmmm, eri, eri_ao, kl, &envs);
         }
 
-        free(eri_ao);
-        free(mo_r);
-        free(mo_i);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+}
+        pyscf_free(eri_ao);
+        pyscf_free(mo_r);
+        pyscf_free(mo_i);
 }
 
 void AO2MOr_e2_drv(void (*ftrans)(), int (*fmmm)(),
@@ -876,8 +891,8 @@ void AO2MOr_e2_drv(void (*ftrans)(), int (*fmmm)(),
 {
         int nmo = MAX(orbs_slice[1], orbs_slice[3]);
         int i;
-        double *mo_r = malloc(sizeof(double) * nao * nmo);
-        double *mo_i = malloc(sizeof(double) * nao * nmo);
+        double *mo_r = pyscf_malloc(sizeof(double) * nao * nmo);
+        double *mo_i = pyscf_malloc(sizeof(double) * nao * nmo);
         for (i = 0; i < nao*nmo; i++) {
                 mo_r[i] = creal(mo_coeff[i]);
                 mo_i[i] = cimag(mo_coeff[i]);
@@ -898,11 +913,21 @@ void AO2MOr_e2_drv(void (*ftrans)(), int (*fmmm)(),
 #pragma omp parallel default(none) \
         shared(ftrans, fmmm, vout, vin, nijcount, envs) \
         private(i)
+{
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
 #pragma omp for nowait schedule(static)
         for (i = 0; i < nijcount; i++) {
                 (*ftrans)(fmmm, vout, vin, i, &envs);
         }
-        free(mo_r);
-        free(mo_i);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+}
+        pyscf_free(mo_r);
+        pyscf_free(mo_i);
 }
 

--- a/pyscf/lib/ao2mo/restore_eri.c
+++ b/pyscf/lib/ao2mo/restore_eri.c
@@ -27,7 +27,7 @@ void AO2MOrestore_nr8to1(double *eri8, double *eri1, int norb)
         size_t i, j, ij;
         size_t d2 = norb * norb;
         size_t d3 = norb * norb * norb;
-        double *buf = malloc(sizeof(double)*npair);
+        double *buf = pyscf_malloc(sizeof(double)*npair);
 
         for (ij = 0, i = 0; i < norb; i++) {
         for (j = 0; j < i+1; j++, ij++) {
@@ -37,7 +37,7 @@ void AO2MOrestore_nr8to1(double *eri8, double *eri1, int norb)
                         NPdcopy(eri1+j*d3+i*d2, eri1+i*d3+j*d2, norb*norb);
                 }
         } }
-        free(buf);
+        pyscf_free(buf);
 }
 
 void AO2MOrestore_nr4to1(double *eri4, double *eri1, int norb)

--- a/pyscf/lib/cc/ccsd_grad.c
+++ b/pyscf/lib/cc/ccsd_grad.c
@@ -21,6 +21,8 @@
 #include "config.h"
 #include "vhf/fblas.h"
 #include "ao2mo/nr_ao2mo.h"
+#include "np_helper/np_helper.h"
+
 #define OUTPUTIJ        1
 #define INPUT_IJ        2
 
@@ -83,8 +85,8 @@ void CCvhfs2kl(double *eri, double *dm, double *vj, double *vk, int ni, int nj)
 
 #pragma omp parallel private(ij, i, j, off)
         {
-                double *vj_priv = malloc(sizeof(double)*ni*nj);
-                double *vk_priv = malloc(sizeof(double)*ni*nj);
+                double *vj_priv = pyscf_malloc(sizeof(double)*ni*nj);
+                double *vk_priv = pyscf_malloc(sizeof(double)*ni*nj);
                 for (i = 0; i < ni * nj; i++) {
                         vj_priv[i] = 0;
                         vk_priv[i] = 0;
@@ -104,8 +106,8 @@ void CCvhfs2kl(double *eri, double *dm, double *vj, double *vk, int ni, int nj)
                                 vk[i] += vk_priv[i];
                         }
                 }
-                free(vj_priv);
-                free(vk_priv);
+                pyscf_free(vj_priv);
+                pyscf_free(vk_priv);
         }
 }
 

--- a/pyscf/lib/cc/ccsd_pack.c
+++ b/pyscf/lib/cc/ccsd_pack.c
@@ -23,6 +23,10 @@
 #include "np_helper/np_helper.h"
 #include "vhf/fblas.h"
 
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
+
 /*
  * a * v1 + b * v2.transpose(0,2,1,3)
  */
@@ -55,6 +59,7 @@ void CCmake_0213(double *out, double *v1, double *v2, int count, int m,
  */
 void CCsum021(double *out, double *v1, double *v2, int count, int m)
 {
+#ifndef PYSCF_USE_MKL
 #pragma omp parallel default(none) \
         shared(count, m, out, v1, v2)
 {
@@ -72,6 +77,15 @@ void CCsum021(double *out, double *v1, double *v2, int count, int m)
                 } }
         }
 }
+#else
+        mkl_domatadd_batch_strided(
+                'R', 'N', 'T', m, m,
+                1.0, v1, m, m * m,
+                1.0, v2, m, m * m,
+                out, m, m * m,
+                count
+        );
+#endif
 }
 
 /*
@@ -80,6 +94,7 @@ void CCsum021(double *out, double *v1, double *v2, int count, int m)
 void CCmake_021(double *out, double *v1, double *v2, int count, int m,
                 double a, double b)
 {
+#ifndef PYSCF_USE_MKL
         if (a == 1 && b == 1) {
                 return CCsum021(out, v1, v2, count, m);
         }
@@ -101,6 +116,15 @@ void CCmake_021(double *out, double *v1, double *v2, int count, int m,
                 } }
         }
 }
+#else
+        mkl_domatadd_batch_strided(
+                'R', 'N', 'T', m, m,
+                a, v1, m, m * m,
+                b, v2, m, m * m,
+                out, m, m * m,
+                count
+        );
+#endif
 }
 
 /*
@@ -151,9 +175,12 @@ void CCload_eri(double *out, double *eri, int *orbs_slice, int nao)
 #pragma omp parallel default(none) \
         shared(out, eri, i1, j1, ni, nj, nn, nao, nao_pair)
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         int i, j, k, l, ij;
         double *pout;
-        double *buf = malloc(sizeof(double) * nao*nao);
+        double *buf = pyscf_malloc(sizeof(double) * nao*nao);
 #pragma omp for schedule (static)
         for (ij = 0; ij < ni*nj; ij++) {
                 i = ij / nj;
@@ -165,7 +192,10 @@ void CCload_eri(double *out, double *eri, int *orbs_slice, int nao)
                         pout[k*nn+l] = buf[k*nao+l];
                 } }
         }
-        free(buf);
+        pyscf_free(buf);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -188,7 +218,7 @@ void CCsd_sort_inplace(double *eri, int nocc, int nvir, int count)
         size_t nocc_pair = nocc * (nocc+1) /2;
         size_t nvir_pair = nvir * (nvir+1) /2;
         double *peri, *pout;
-        double *buf = malloc(sizeof(double) * nocc*nvir);
+        double *buf = pyscf_malloc(sizeof(double) * nocc*nvir);
 #pragma omp for schedule (static)
         for (ic = 0; ic < count; ic++) {
                 peri = eri + ic*nmo_pair + nvir_pair;
@@ -207,7 +237,7 @@ void CCsd_sort_inplace(double *eri, int nocc, int nvir, int count)
                 pout = eri + ic*nmo_pair + nvir_pair + nocc_pair;
                 NPdcopy(pout, buf, nocc*nvir);
         }
-        free(buf);
+        pyscf_free(buf);
 }
 }
 

--- a/pyscf/lib/cc/ccsd_t.c
+++ b/pyscf/lib/cc/ccsd_t.c
@@ -386,25 +386,29 @@ void CCsd_t_contract(double *e_tot,
 {
         int da = a1 - a0;
         int db = b1 - b0;
-        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        CacheJob *jobs = pyscf_malloc(sizeof(CacheJob) * da*db*b1);
         size_t njobs = _ccsd_t_gen_jobs(jobs, nocc, nvir, a0, a1, b0, b1,
                                         cache_row_a, cache_col_a,
                                         cache_row_b, cache_col_b, sizeof(double));
-        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        int *permute_idx = pyscf_malloc(sizeof(int) * nocc*nocc*nocc * 6);
         _make_permute_indices(permute_idx, nocc);
 #pragma omp parallel default(none) \
         shared(njobs, nocc, nvir, mo_energy, t1T, t2T, nirrep, o_ir_loc, \
                v_ir_loc, oo_ir_loc, orbsym, vooo, fvo, jobs, e_tot, permute_idx, stderr)
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
+
         int a, b, c;
         size_t k;
-        double *cache1 = malloc(sizeof(double) * (nocc*nocc*nocc*3+2));
+        double *cache1 = pyscf_malloc(sizeof(double) * (nocc*nocc*nocc*3+2));
         if (cache1 == NULL) {
-                fprintf(stderr, "malloc(%zu) failed in CCsd_t_contract\n",
+                fprintf(stderr, "pyscf_malloc(%zu) failed in CCsd_t_contract\n",
                         sizeof(double) * nocc*nocc*nocc*3);
                 exit(1);
         }
-        double *t1Thalf = malloc(sizeof(double) * nvir*nocc * 2);
+        double *t1Thalf = pyscf_malloc(sizeof(double) * nvir*nocc * 2);
         double *fvohalf = t1Thalf + nvir*nocc;
         for (k = 0; k < nvir*nocc; k++) {
                 t1Thalf[k] = t1T[k] * .5;
@@ -421,13 +425,17 @@ void CCsd_t_contract(double *e_tot,
                                fvohalf, vooo, cache1, jobs[k].cache, permute_idx,
                                1.0);
         }
-        free(t1Thalf);
-        free(cache1);
+        pyscf_free(t1Thalf);
+        pyscf_free(cache1);
 #pragma omp critical
         *e_tot += e;
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-        free(permute_idx);
-        free(jobs);
+        pyscf_free(permute_idx);
+        pyscf_free(jobs);
 }
 
 void QCIsd_t_contract(double *e_tot,
@@ -441,25 +449,29 @@ void QCIsd_t_contract(double *e_tot,
 {
         int da = a1 - a0;
         int db = b1 - b0;
-        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        CacheJob *jobs = pyscf_malloc(sizeof(CacheJob) * da*db*b1);
         size_t njobs = _ccsd_t_gen_jobs(jobs, nocc, nvir, a0, a1, b0, b1,
                                         cache_row_a, cache_col_a,
                                         cache_row_b, cache_col_b, sizeof(double));
-        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        int *permute_idx = pyscf_malloc(sizeof(int) * nocc*nocc*nocc * 6);
         _make_permute_indices(permute_idx, nocc);
 #pragma omp parallel default(none) \
         shared(njobs, nocc, nvir, mo_energy, t1T, t2T, nirrep, o_ir_loc, \
                v_ir_loc, oo_ir_loc, orbsym, vooo, fvo, jobs, e_tot, permute_idx, stderr)
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
+
         int a, b, c;
         size_t k;
-        double *cache1 = malloc(sizeof(double) * (nocc*nocc*nocc*3+2));
+        double *cache1 = pyscf_malloc(sizeof(double) * (nocc*nocc*nocc*3+2));
         if (cache1 == NULL) {
-                fprintf(stderr, "malloc(%zu) failed in QCIsd_t_contract\n",
+                fprintf(stderr, "pyscf_malloc(%zu) failed in QCIsd_t_contract\n",
                         sizeof(double) * nocc*nocc*nocc*3);
                 exit(1);
         }
-        double *t1Thalf = malloc(sizeof(double) * nvir*nocc * 2);
+        double *t1Thalf = pyscf_malloc(sizeof(double) * nvir*nocc * 2);
         double *fvohalf = t1Thalf + nvir*nocc;
         for (k = 0; k < nvir*nocc; k++) {
                 t1Thalf[k] = t1T[k] * .5;
@@ -476,13 +488,17 @@ void QCIsd_t_contract(double *e_tot,
                                fvohalf, vooo, cache1, jobs[k].cache, permute_idx,
                                2.0);
         }
-        free(t1Thalf);
-        free(cache1);
+        pyscf_free(t1Thalf);
+        pyscf_free(cache1);
 #pragma omp critical
         *e_tot += e;
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-        free(permute_idx);
-        free(jobs);
+        pyscf_free(permute_idx);
+        pyscf_free(jobs);
 }
 
 
@@ -619,28 +635,32 @@ void CCsd_t_zcontract(double complex *e_tot,
 {
         int da = a1 - a0;
         int db = b1 - b0;
-        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        CacheJob *jobs = pyscf_malloc(sizeof(CacheJob) * da*db*b1);
         size_t njobs = _ccsd_t_gen_jobs(jobs, nocc, nvir, a0, a1, b0, b1,
                                         cache_row_a, cache_col_a,
                                         cache_row_b, cache_col_b,
                                         sizeof(double complex));
 
-        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        int *permute_idx = pyscf_malloc(sizeof(int) * nocc*nocc*nocc * 6);
         _make_permute_indices(permute_idx, nocc);
 
 #pragma omp parallel default(none) \
         shared(njobs, nocc, nvir, mo_energy, t1T, t2T, nirrep, o_ir_loc, \
                v_ir_loc, oo_ir_loc, orbsym, vooo, fvo, jobs, e_tot, permute_idx, stderr)
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
+
         int a, b, c;
         size_t k;
-        double complex *cache1 = malloc(sizeof(double complex) * (nocc*nocc*nocc*3+2));
+        double complex *cache1 = pyscf_malloc(sizeof(double complex) * (nocc*nocc*nocc*3+2));
         if (cache1 == NULL) {
-                fprintf(stderr, "malloc(%zu) failed in CCsd_t_zcontract\n",
+                fprintf(stderr, "pyscf_malloc(%zu) failed in CCsd_t_zcontract\n",
                         sizeof(double complex) * nocc*nocc*nocc*3);
                 exit(1);
         }
-        double complex *t1Thalf = malloc(sizeof(double complex) * nvir*nocc * 2);
+        double complex *t1Thalf = pyscf_malloc(sizeof(double complex) * nvir*nocc * 2);
         double complex *fvohalf = t1Thalf + nvir*nocc;
         for (k = 0; k < nvir*nocc; k++) {
                 t1Thalf[k] = t1T[k] * .5;
@@ -657,13 +677,17 @@ void CCsd_t_zcontract(double complex *e_tot,
                                fvohalf, vooo, cache1, jobs[k].cache, permute_idx,
                                1.0);
         }
-        free(t1Thalf);
-        free(cache1);
+        pyscf_free(t1Thalf);
+        pyscf_free(cache1);
 #pragma omp critical
         *e_tot += e;
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-        free(permute_idx);
-        free(jobs);
+        pyscf_free(permute_idx);
+        pyscf_free(jobs);
 }
 
 void QCIsd_t_zcontract(double complex *e_tot,
@@ -677,28 +701,32 @@ void QCIsd_t_zcontract(double complex *e_tot,
 {
         int da = a1 - a0;
         int db = b1 - b0;
-        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*b1);
+        CacheJob *jobs = pyscf_malloc(sizeof(CacheJob) * da*db*b1);
         size_t njobs = _ccsd_t_gen_jobs(jobs, nocc, nvir, a0, a1, b0, b1,
                                         cache_row_a, cache_col_a,
                                         cache_row_b, cache_col_b,
                                         sizeof(double complex));
 
-        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        int *permute_idx = pyscf_malloc(sizeof(int) * nocc*nocc*nocc * 6);
         _make_permute_indices(permute_idx, nocc);
 
 #pragma omp parallel default(none) \
         shared(njobs, nocc, nvir, mo_energy, t1T, t2T, nirrep, o_ir_loc, \
                v_ir_loc, oo_ir_loc, orbsym, vooo, fvo, jobs, e_tot, permute_idx, stderr)
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
+
         int a, b, c;
         size_t k;
-        double complex *cache1 = malloc(sizeof(double complex) * (nocc*nocc*nocc*3+2));
+        double complex *cache1 = pyscf_malloc(sizeof(double complex) * (nocc*nocc*nocc*3+2));
         if (cache1 == NULL) {
-                fprintf(stderr, "malloc(%zu) failed in QCIsd_t_zcontract\n",
+                fprintf(stderr, "pyscf_malloc(%zu) failed in QCIsd_t_zcontract\n",
                         sizeof(double complex) * nocc*nocc*nocc*3);
                 exit(1);
         }
-        double complex *t1Thalf = malloc(sizeof(double complex) * nvir*nocc * 2);
+        double complex *t1Thalf = pyscf_malloc(sizeof(double complex) * nvir*nocc * 2);
         double complex *fvohalf = t1Thalf + nvir*nocc;
         for (k = 0; k < nvir*nocc; k++) {
                 t1Thalf[k] = t1T[k] * .5;
@@ -715,13 +743,17 @@ void QCIsd_t_zcontract(double complex *e_tot,
                                fvohalf, vooo, cache1, jobs[k].cache, permute_idx,
                                2.0);
         }
-        free(t1Thalf);
-        free(cache1);
+        pyscf_free(t1Thalf);
+        pyscf_free(cache1);
 #pragma omp critical
         *e_tot += e;
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-        free(permute_idx);
-        free(jobs);
+        pyscf_free(permute_idx);
+        pyscf_free(jobs);
 }
 
 
@@ -866,25 +898,29 @@ void MPICCsd_t_contract(double *e_tot, double *mo_energy, double *t1T,
         int da = a1 - a0;
         int db = b1 - b0;
         int dc = c1 - c0;
-        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*dc);
+        CacheJob *jobs = pyscf_malloc(sizeof(CacheJob) * da*db*dc);
         size_t njobs = _MPICCsd_t_gen_jobs(jobs, nocc, nvir, slices, data_ptrs);
 
-        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        int *permute_idx = pyscf_malloc(sizeof(int) * nocc*nocc*nocc * 6);
         _make_permute_indices(permute_idx, nocc);
 
 #pragma omp parallel default(none) \
         shared(njobs, nocc, nvir, mo_energy, t1T, fvo, jobs, e_tot, slices, \
                data_ptrs, permute_idx, stderr)
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
+
         int a, b, c;
         size_t k;
-        double *cache1 = malloc(sizeof(double) * (nocc*nocc*nocc*3+2));
+        double *cache1 = pyscf_malloc(sizeof(double) * (nocc*nocc*nocc*3+2));
         if (cache1 == NULL) {
-                fprintf(stderr, "malloc(%zu) failed in MPICCsd_t_contract\n",
+                fprintf(stderr, "pyscf_malloc(%zu) failed in MPICCsd_t_contract\n",
                         sizeof(double) * nocc*nocc*nocc*3);
                 exit(1);
         }
-        double *t1Thalf = malloc(sizeof(double) * nvir*nocc * 2);
+        double *t1Thalf = pyscf_malloc(sizeof(double) * nvir*nocc * 2);
         double *fvohalf = t1Thalf + nvir*nocc;
         for (k = 0; k < nvir*nocc; k++) {
                 t1Thalf[k] = t1T[k] * .5;
@@ -900,13 +936,17 @@ void MPICCsd_t_contract(double *e_tot, double *mo_energy, double *t1T,
                                     fvohalf, slices, data_ptrs, cache1,
                                     permute_idx, 1.0);
         }
-        free(t1Thalf);
-        free(cache1);
+        pyscf_free(t1Thalf);
+        pyscf_free(cache1);
 #pragma omp critical
         *e_tot += e;
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-        free(permute_idx);
-        free(jobs);
+        pyscf_free(permute_idx);
+        pyscf_free(jobs);
 }
 
 /*****************************************************************************
@@ -1099,25 +1139,29 @@ void CCsd_zcontract_t3T(double complex *t3Tw, double complex *t3Tv, double *mo_e
         int da = a1 - a0;
         int db = b1 - b0;
         int dc = c1 - c0;
-        CacheJob *jobs = malloc(sizeof(CacheJob) * da*db*dc);
+        CacheJob *jobs = pyscf_malloc(sizeof(CacheJob) * da*db*dc);
         size_t njobs = _CCsd_t_gen_jobs_full(jobs, nocc, nvir, slices);
 
-        int *permute_idx = malloc(sizeof(int) * nocc*nocc*nocc * 6);
+        int *permute_idx = pyscf_malloc(sizeof(int) * nocc*nocc*nocc * 6);
         _make_permute_indices(permute_idx, nocc);
 
 #pragma omp parallel default(none) \
         shared(njobs, nocc, nvir, nkpts, t3Tw, t3Tv, mo_offset, mo_energy, t1T, fvo, jobs, slices, \
                data_ptrs, permute_idx, stderr)
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
+
         int a, b, c;
         size_t k;
-        complex double *cache1 = malloc(sizeof(double complex) * (nocc*nocc*nocc*3+2));
+        complex double *cache1 = pyscf_malloc(sizeof(double complex) * (nocc*nocc*nocc*3+2));
         if (cache1 == NULL) {
-                fprintf(stderr, "malloc(%zu) failed in CCsd_zcontract_t3T\n",
+                fprintf(stderr, "pyscf_malloc(%zu) failed in CCsd_zcontract_t3T\n",
                         sizeof(double complex) * nocc*nocc*nocc*3);
                 exit(1);
         }
-        complex double *t1Thalf = malloc(sizeof(double complex) * nkpts*nvir*nocc*2);
+        complex double *t1Thalf = pyscf_malloc(sizeof(double complex) * nkpts*nvir*nocc*2);
         complex double *fvohalf = t1Thalf + nkpts*nvir*nocc;
         for (k = 0; k < nkpts*nvir*nocc; k++) {
                 t1Thalf[k] = t1T[k] * .5;
@@ -1132,10 +1176,14 @@ void CCsd_zcontract_t3T(double complex *t3Tw, double complex *t3Tv, double *mo_e
                                fvohalf, slices, data_ptrs, cache1,
                                permute_idx);
         }
-        free(t1Thalf);
-        free(cache1);
+        pyscf_free(t1Thalf);
+        pyscf_free(cache1);
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-        free(jobs);
-        free(permute_idx);
+        pyscf_free(jobs);
+        pyscf_free(permute_idx);
 }
 

--- a/pyscf/lib/dft/CMakeLists.txt
+++ b/pyscf/lib/dft/CMakeLists.txt
@@ -34,6 +34,11 @@ add_library(xc_itrf SHARED libxc_itrf.c)
 set_target_properties(xc_itrf PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 target_link_libraries(xc_itrf xc ${OPENMP_C_PROPERTIES})
+
+if(USE_MKL)
+  target_link_libraries(xc_itrf ${BLAS_LIBRARIES})
+endif()
+
 endif()
 
 if(ENABLE_XCFUN)

--- a/pyscf/lib/dft/grid_basis.c
+++ b/pyscf/lib/dft/grid_basis.c
@@ -34,6 +34,7 @@ void VXCgen_grid(double *out, double *coords, double *atm_coords,
         int i, j;
         double dx, dy, dz;
         double *atom_dist = pyscf_malloc(sizeof(double) * natm*natm);
+
         for (i = 0; i < natm; i++) {
                 for (j = 0; j < i; j++) {
                         dx = atm_coords[i*3+0] - atm_coords[j*3+0];

--- a/pyscf/lib/dft/grid_basis.c
+++ b/pyscf/lib/dft/grid_basis.c
@@ -33,7 +33,7 @@ void VXCgen_grid(double *out, double *coords, double *atm_coords,
         const size_t Ngrids = ngrids;
         int i, j;
         double dx, dy, dz;
-        double *atom_dist = malloc(sizeof(double) * natm*natm);
+        double *atom_dist = pyscf_malloc(sizeof(double) * natm*natm);
         for (i = 0; i < natm; i++) {
                 for (j = 0; j < i; j++) {
                         dx = atm_coords[i*3+0] - atm_coords[j*3+0];
@@ -45,7 +45,11 @@ void VXCgen_grid(double *out, double *coords, double *atm_coords,
 
 #pragma omp parallel private(i, j, dx, dy, dz)
 {
-        double *_buf = malloc(sizeof(double) * ((natm*2+1)*GRIDS_BLOCK + ALIGNMENT));
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
+        double *_buf = pyscf_malloc(sizeof(double) * ((natm*2+1)*GRIDS_BLOCK + ALIGNMENT));
         double *buf = (double *)((uintptr_t)(_buf + ALIGNMENT - 1) & (-(uintptr_t)(ALIGNMENT*8)));
         double *g = buf + natm * GRIDS_BLOCK;
         double *grid_dist = g + GRIDS_BLOCK;
@@ -95,8 +99,12 @@ void VXCgen_grid(double *out, double *coords, double *atm_coords,
                         }
                 }
         }
-        free(_buf);
+        pyscf_free(_buf);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(atom_dist);
+        pyscf_free(atom_dist);
 }
 

--- a/pyscf/lib/dft/grid_collocate.c
+++ b/pyscf/lib/dft/grid_collocate.c
@@ -322,14 +322,14 @@ void grid_collocate_drv(void (*eval_rho)(), RS_Grid** rs_rho, double* dm, TaskLi
     //const int naoi = ish_ao_loc[ish1] - ish_ao_loc[ish0];
     const int naoj = jsh_ao_loc[jsh1] - jsh_ao_loc[jsh0];
 
-    double **gto_norm_i = (double**) malloc(sizeof(double*) * nish);
-    double **cart2sph_coeff_i = (double**) malloc(sizeof(double*) * nish);
+    double **gto_norm_i = (double**) pyscf_malloc(sizeof(double*) * nish);
+    double **cart2sph_coeff_i = (double**) pyscf_malloc(sizeof(double*) * nish);
     get_cart2sph_coeff(cart2sph_coeff_i, gto_norm_i, ish0, ish1, ish_bas, ish_env, cart);
     double **gto_norm_j = gto_norm_i;
     double **cart2sph_coeff_j = cart2sph_coeff_i;
     if (hermi != 1) {
-        gto_norm_j = (double**) malloc(sizeof(double*) * njsh);
-        cart2sph_coeff_j = (double**) malloc(sizeof(double*) * njsh);
+        gto_norm_j = (double**) pyscf_malloc(sizeof(double*) * njsh);
+        cart2sph_coeff_j = (double**) pyscf_malloc(sizeof(double*) * njsh);
         get_cart2sph_coeff(cart2sph_coeff_j, gto_norm_j, jsh0, jsh1, jsh_bas, jsh_env, cart);
     }
 
@@ -383,10 +383,14 @@ void grid_collocate_drv(void (*eval_rho)(), RS_Grid** rs_rho, double* dm, TaskLi
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
     PGFPair *pgfpair = NULL;
     int iblock, itask, ish, jsh;
     double *ptr_gto_norm_i, *ptr_gto_norm_j;
-    double *cache0 = malloc(sizeof(double) * cache_size);
+    double *cache0 = pyscf_malloc(sizeof(double) * cache_size);
     double *dm_cart = cache0;
     double *dm_pgf = cache0 + ish_nprim_max*_LEN_CART[ish_lmax]*jsh_nprim_max*_LEN_CART[jsh_lmax];
     double *cache = dm_pgf + _LEN_CART[ish_lmax]*_LEN_CART[jsh_lmax]; 
@@ -396,7 +400,7 @@ void grid_collocate_drv(void (*eval_rho)(), RS_Grid** rs_rho, double* dm, TaskLi
     if (thread_id == 0) {
         rho_priv = rho;
     } else {
-        rho_priv = calloc(comp*ngrids, sizeof(double));
+        rho_priv = pyscf_calloc(comp*ngrids, sizeof(double));
     }
     rhobufs[thread_id] = rho_priv;
 
@@ -420,14 +424,18 @@ void grid_collocate_drv(void (*eval_rho)(), RS_Grid** rs_rho, double* dm, TaskLi
         }
     }
 
-    free(cache0);
+    pyscf_free(cache0);
     NPomp_dsum_reduce_inplace(rhobufs, comp*ngrids);
     if (thread_id != 0) {
-        free(rho_priv);
+        pyscf_free(rho_priv);
     }
-}
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+} // pragma omp parallel
     if (task_loc) {
-        free(task_loc);
+        pyscf_free(task_loc);
     }
     } // loop ilevel
 
@@ -453,18 +461,22 @@ void build_core_density(void (*eval_rho)(), double* rho,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
     int ia, ib;
     double alpha, coeff, charge, rad, fac;
     double dm[] = {1.0};
     double *r0;
-    double *cache = (double*) malloc(sizeof(double) * cache_size);
+    double *cache = (double*) pyscf_malloc(sizeof(double) * cache_size);
 
     int thread_id = omp_get_thread_num();
     double *rho_priv;
     if (thread_id == 0) {
         rho_priv = rho;
     } else {
-        rho_priv = calloc(ngrids, sizeof(double));
+        rho_priv = pyscf_calloc(ngrids, sizeof(double));
     }
     rhobufs[thread_id] = rho_priv;
 
@@ -480,11 +492,11 @@ void build_core_density(void (*eval_rho)(), double* rho,
         eval_rho(rho_priv, dm, 1, 0, 0, alpha, 0., r0, r0,
                  fac, rad, dimension, dh, a, b, mesh, cache);
     }
-    free(cache);
+    pyscf_free(cache);
 
     NPomp_dsum_reduce_inplace(rhobufs, ngrids);
     if (thread_id != 0) {
-        free(rho_priv);
+        pyscf_free(rho_priv);
     }
 }
 }
@@ -561,14 +573,14 @@ void eval_pgfpairs(TaskList** task_list,
     //const int naoi = ish_ao_loc[ish1] - ish_ao_loc[ish0];
     //const int naoj = jsh_ao_loc[jsh1] - jsh_ao_loc[jsh0];
 
-    double **gto_norm_i = (double**) malloc(sizeof(double*) * nish);
-    double **cart2sph_coeff_i = (double**) malloc(sizeof(double*) * nish);
+    double **gto_norm_i = (double**) pyscf_malloc(sizeof(double*) * nish);
+    double **cart2sph_coeff_i = (double**) pyscf_malloc(sizeof(double*) * nish);
     get_cart2sph_coeff(cart2sph_coeff_i, gto_norm_i, ish0, ish1, ish_bas, ish_env, cart);
     double **gto_norm_j = gto_norm_i;
     double **cart2sph_coeff_j = cart2sph_coeff_i;
     if (hermi != 1) {
-        gto_norm_j = (double**) malloc(sizeof(double*) * njsh);
-        cart2sph_coeff_j = (double**) malloc(sizeof(double*) * njsh);
+        gto_norm_j = (double**) pyscf_malloc(sizeof(double*) * njsh);
+        cart2sph_coeff_j = (double**) pyscf_malloc(sizeof(double*) * njsh);
         get_cart2sph_coeff(cart2sph_coeff_j, gto_norm_j, jsh0, jsh1, jsh_bas, jsh_env, cart);
     }
 
@@ -620,10 +632,14 @@ void eval_pgfpairs(TaskList** task_list,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
     PGFPair *pgfpair = NULL;
     int iblock, itask, ish, jsh;
     double *ptr_gto_norm_i, *ptr_gto_norm_j;
-    double *cache = malloc(sizeof(double) * cache_size);
+    double *cache = pyscf_malloc(sizeof(double) * cache_size);
 
     #pragma omp for schedule(dynamic)
     for (iblock = 0; iblock < nblock; iblock+=2) {
@@ -641,10 +657,14 @@ void eval_pgfpairs(TaskList** task_list,
         }
     }
 
-    free(cache);
-}
+    pyscf_free(cache);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+} // pragma omp parallel
     if (task_loc) {
-        free(task_loc);
+        pyscf_free(task_loc);
     }
     } // loop ilevel
 

--- a/pyscf/lib/dft/grid_collocate.c
+++ b/pyscf/lib/dft/grid_collocate.c
@@ -498,6 +498,10 @@ void build_core_density(void (*eval_rho)(), double* rho,
     if (thread_id != 0) {
         pyscf_free(rho_priv);
     }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 

--- a/pyscf/lib/dft/grid_common.c
+++ b/pyscf/lib/dft/grid_common.c
@@ -97,10 +97,6 @@ void get_cart2sph_coeff(double** contr_coeff, double** gto_norm,
                               ncart, nsph, nprim, nctr,\
                               ptr_exp, ptr_coeff)
 {
-#ifdef PYSCF_USE_MKL
-        int save = mkl_set_num_threads_local(1);
-#endif
-
     #pragma omp for schedule(dynamic) 
     for (ish = ish0; ish < ish1; ish++) {
         l = bas[ANG_OF+ish*BAS_SLOTS];
@@ -137,9 +133,6 @@ void get_cart2sph_coeff(double** contr_coeff, double** gto_norm,
         pyscf_free(buf);
     }
 
-#ifdef PYSCF_USE_MKL
-        mkl_set_num_threads_local(save);
-#endif
 }
 
     for (l = 0; l <= lmax; l++) {

--- a/pyscf/lib/dft/grid_common.c
+++ b/pyscf/lib/dft/grid_common.c
@@ -72,24 +72,24 @@ void get_cart2sph_coeff(double** contr_coeff, double** gto_norm,
     int ptr_exp, ptr_coeff;
     int ish, ipgf, ic, i, j;
 
-    double **c2s = (double**) malloc(sizeof(double*) * (lmax+1));
+    double **c2s = (double**) pyscf_malloc(sizeof(double*) * (lmax+1));
     for (l = 0; l <= lmax; l++) {
         ncart = _LEN_CART[l];
         if (l <= 1 || cart == 1) {
-            c2s[l] = (double*) calloc(ncart*ncart, sizeof(double));
+            c2s[l] = (double*) pyscf_calloc(ncart*ncart, sizeof(double));
             for (i = 0; i < ncart; i++) {
                 c2s[l][i*ncart + i] = 1;
             }
         }
         else {
             nsph = 2*l + 1;
-            c2s[l] = (double*) calloc(nsph*ncart, sizeof(double));
-            double* gcart = (double*) calloc(ncart*ncart, sizeof(double));
+            c2s[l] = (double*) pyscf_calloc(nsph*ncart, sizeof(double));
+            double* gcart = (double*) pyscf_calloc(ncart*ncart, sizeof(double));
             for (i = 0; i < ncart; i++) {
                 gcart[i*ncart + i] = 1;
             }
             CINTc2s_ket_sph(c2s[l], ncart, gcart, l);
-            free(gcart);
+            pyscf_free(gcart);
         }
     }
 
@@ -97,6 +97,10 @@ void get_cart2sph_coeff(double** contr_coeff, double** gto_norm,
                               ncart, nsph, nprim, nctr,\
                               ptr_exp, ptr_coeff)
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
     #pragma omp for schedule(dynamic) 
     for (ish = ish0; ish < ish1; ish++) {
         l = bas[ANG_OF+ish*BAS_SLOTS];
@@ -106,19 +110,19 @@ void get_cart2sph_coeff(double** contr_coeff, double** gto_norm,
         nctr = bas[NCTR_OF+ish*BAS_SLOTS];
 
         ptr_exp = bas[PTR_EXP+ish*BAS_SLOTS];
-        gto_norm[ish] = (double*) malloc(sizeof(double) * nprim);
+        gto_norm[ish] = (double*) pyscf_malloc(sizeof(double) * nprim);
         for (ipgf = 0; ipgf < nprim; ipgf++) {
             gto_norm[ish][ipgf] = CINTgto_norm(l, env[ptr_exp+ipgf]);
         }
 
         ptr_coeff = bas[PTR_COEFF+ish*BAS_SLOTS];
-        double *buf = (double*) calloc(nctr*nprim, sizeof(double));
+        double *buf = (double*) pyscf_calloc(nctr*nprim, sizeof(double));
         for (ipgf = 0; ipgf < nprim; ipgf++) {
             double inv_norm = 1./gto_norm[ish][ipgf];
             daxpy_(&nctr, &inv_norm, env+ptr_coeff+ipgf, &nprim, buf+ipgf, &nprim);
         }
 
-        contr_coeff[ish] = (double*) malloc(sizeof(double) * nprim*ncart*nctr*nsph);
+        contr_coeff[ish] = (double*) pyscf_malloc(sizeof(double) * nprim*ncart*nctr*nsph);
         double* ptr_contr_coeff = contr_coeff[ish];
         for (ipgf = 0; ipgf < nprim; ipgf++) {
             for (i = 0; i < ncart; i++) {
@@ -130,14 +134,18 @@ void get_cart2sph_coeff(double** contr_coeff, double** gto_norm,
                 }
             }
         }
-        free(buf);
+        pyscf_free(buf);
     }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 
     for (l = 0; l <= lmax; l++) {
-        free(c2s[l]);
+        pyscf_free(c2s[l]);
     }
-    free(c2s);
+    pyscf_free(c2s);
 }
 
 
@@ -146,14 +154,14 @@ void del_cart2sph_coeff(double** contr_coeff, double** gto_norm, int ish0, int i
     int ish;
     for (ish = ish0; ish < ish1; ish++) {
         if (contr_coeff[ish]) {
-            free(contr_coeff[ish]);
+            pyscf_free(contr_coeff[ish]);
         }
         if (gto_norm[ish]) {
-            free(gto_norm[ish]);
+            pyscf_free(gto_norm[ish]);
         }
     }
-    free(contr_coeff);
-    free(gto_norm);
+    pyscf_free(contr_coeff);
+    pyscf_free(gto_norm);
 }
 
 

--- a/pyscf/lib/dft/grid_integrate.c
+++ b/pyscf/lib/dft/grid_integrate.c
@@ -86,6 +86,7 @@ static void fill_tril(double* mat, int comp, int* ish_ao_loc, int* jsh_ao_loc,
     double *pmat_up = mat + i0*((size_t)naoj) + j0;
     double *pmat_low = mat + j0*((size_t)naoj) + i0;
     int ic, i, j;
+#ifndef PYSCF_USE_MKL
     for (ic = 0; ic < comp; ic++) {
         for (i = 0; i < ni; i++) {
             for (j = 0; j < nj; j++) {
@@ -95,6 +96,13 @@ static void fill_tril(double* mat, int comp, int* ish_ao_loc, int* jsh_ao_loc,
         pmat_up += nao2;
         pmat_low += nao2;
     }
+#else
+    mkl_domatcopy_batch_strided(
+        'R', 'T', ni, nj,
+        1.0, pmat_up, naoj, nao2,
+        pmat_low, naoj, nao2, comp
+    );
+#endif
 }
 
 

--- a/pyscf/lib/dft/grid_integrate.c
+++ b/pyscf/lib/dft/grid_integrate.c
@@ -1254,14 +1254,14 @@ void grid_integrate_drv(int (*eval_ints)(), double* mat, double* weights, TaskLi
         jsh_nctr_max = get_nctr_max(jsh0, jsh1, jsh_bas);
     }
 
-    double **gto_norm_i = (double**) malloc(sizeof(double*) * nish);
-    double **cart2sph_coeff_i = (double**) malloc(sizeof(double*) * nish);
+    double **gto_norm_i = (double**) pyscf_malloc(sizeof(double*) * nish);
+    double **cart2sph_coeff_i = (double**) pyscf_malloc(sizeof(double*) * nish);
     get_cart2sph_coeff(cart2sph_coeff_i, gto_norm_i, ish0, ish1, ish_bas, ish_env, cart);
     double **gto_norm_j = gto_norm_i;
     double **cart2sph_coeff_j = cart2sph_coeff_i;
     if (hermi != 1) {
-        gto_norm_j = (double**) malloc(sizeof(double*) * njsh);
-        cart2sph_coeff_j = (double**) malloc(sizeof(double*) * njsh);
+        gto_norm_j = (double**) pyscf_malloc(sizeof(double*) * njsh);
+        cart2sph_coeff_j = (double**) pyscf_malloc(sizeof(double*) * njsh);
         get_cart2sph_coeff(cart2sph_coeff_j, gto_norm_j, jsh0, jsh1, jsh_bas, jsh_env, cart);
     }
 
@@ -1275,11 +1275,15 @@ void grid_integrate_drv(int (*eval_ints)(), double* mat, double* weights, TaskLi
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
     int ish, jsh, itask, iblock;
     int li, lj, ish_nprim, jsh_nprim;
     PGFPair *pgfpair = NULL;
     double *ptr_gto_norm_i, *ptr_gto_norm_j;
-    double *cache0 = malloc(sizeof(double) * cache_size);
+    double *cache0 = pyscf_malloc(sizeof(double) * cache_size);
     double *dm_cart = cache0;
     int len_dm_cart = comp*ish_nprim_max*_LEN_CART[ish_lmax]*jsh_nprim_max*_LEN_CART[jsh_lmax];
     double *cache = dm_cart + len_dm_cart;
@@ -1313,11 +1317,15 @@ void grid_integrate_drv(int (*eval_ints)(), double* mat, double* weights, TaskLi
                       ish, jsh, ish0, jsh0, naoi, naoj);
         }
     }
-    free(cache0);
+    pyscf_free(cache0);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 
     if (task_loc) {
-        free(task_loc);
+        pyscf_free(task_loc);
     }
     del_cart2sph_coeff(cart2sph_coeff_i, gto_norm_i, ish0, ish1);
     if (hermi != 1) {
@@ -1337,10 +1345,14 @@ void int_gauss_charge_v_rs(int (*eval_ints)(), double* out, double* v_rs, int co
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
     int ia, ib;
     double alpha, coeff, charge, rad, fac;
     double *r0;
-    double *cache = (double*) malloc(sizeof(double) * cache_size);
+    double *cache = (double*) pyscf_malloc(sizeof(double) * cache_size);
     #pragma omp for schedule(static)
     for (ib = 0; ib < nbas; ib++) {
         ia = bas[ib*BAS_SLOTS+ATOM_OF];
@@ -1353,6 +1365,10 @@ void int_gauss_charge_v_rs(int (*eval_ints)(), double* out, double* v_rs, int co
         (*eval_ints)(v_rs, out+ia*comp, comp, 0, 0, alpha, 0.0, r0, r0, 
                      fac, rad, dimension, dh, a, b, mesh, cache);
     }
-    free(cache);
+    pyscf_free(cache);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }

--- a/pyscf/lib/dft/multigrid.c
+++ b/pyscf/lib/dft/multigrid.c
@@ -358,7 +358,7 @@ void update_task_list(TaskList** task_list, int grid_level,
     t0->ntasks += 1;
     if (t0->ntasks > t0->buf_size) {
         t0->buf_size += ADD_SIZE;
-        t0->pgfpairs = (PGFPair**) realloc(t0->pgfpairs, sizeof(PGFPair*) * t0->buf_size);
+        t0->pgfpairs = (PGFPair**) pyscf_realloc(t0->pgfpairs, sizeof(PGFPair*) * t0->buf_size);
     }
     init_pgfpair(t0->pgfpairs + t0->ntasks - 1,
                  ish, ipgf, jsh, jpgf, iL, radius);
@@ -377,7 +377,7 @@ void merge_task_list(TaskList** task_list, TaskList** task_list_loc)
         int ntasks_loc = t1->ntasks;
         t0->ntasks += ntasks_loc;
         t0->buf_size = t0->ntasks;
-        t0->pgfpairs = (PGFPair**) realloc(t0->pgfpairs, sizeof(PGFPair*) * t0->buf_size);
+        t0->pgfpairs = (PGFPair**) pyscf_realloc(t0->pgfpairs, sizeof(PGFPair*) * t0->buf_size);
         PGFPair** ptr_pgfpairs = t0->pgfpairs + itask_off;
         PGFPair** ptr_pgfpairs_loc = t1->pgfpairs;
         for (itask = 0; itask < ntasks_loc; itask++) {
@@ -543,7 +543,7 @@ int get_task_loc(int** task_loc, PGFPair** pgfpairs, int ntasks,
         }
     }
     n += 2;
-    *task_loc = (int*)realloc(buf, sizeof(int) * n);
+    *task_loc = (int*)pyscf_realloc(buf, sizeof(int) * n);
     return n;
 }
 
@@ -600,7 +600,7 @@ int get_task_loc_diff_ish(int** task_loc, PGFPair** pgfpairs, int ntasks,
         }
     }
     n += 2;
-    *task_loc = (int*)realloc(buf, sizeof(int) * n);
+    *task_loc = (int*)pyscf_realloc(buf, sizeof(int) * n);
     return n;
 }
 */
@@ -626,7 +626,7 @@ void update_task_index(Task_Index* task_idx, int itask)
     task_idx->ntasks += 1;
     if (task_idx->bufsize < task_idx->ntasks) {
         task_idx->bufsize += 10;
-        task_idx->task_index = (int*)realloc(task_idx->task_index, sizeof(int) * task_idx->bufsize);
+        task_idx->task_index = (int*)pyscf_realloc(task_idx->task_index, sizeof(int) * task_idx->bufsize);
     }
     task_idx->task_index[task_idx->ntasks-1] = itask;
 }

--- a/pyscf/lib/dft/nr_numint.c
+++ b/pyscf/lib/dft/nr_numint.c
@@ -221,10 +221,6 @@ void VXC_dscale_ao(double *aow, double *ao, double *wv,
 {
 #pragma omp parallel
 {
-#ifdef PYSCF_USE_MKL
-        int save = mkl_set_num_threads_local(1);
-#endif
-
         size_t Ngrids = ngrids;
         size_t ao_size = nao * Ngrids;
         int i, j, ic;
@@ -240,10 +236,6 @@ void VXC_dscale_ao(double *aow, double *ao, double *wv,
                         aow[i*Ngrids+j] += pao[ic*ao_size+j] * wv[ic*Ngrids+j];
                 } }
         }
-
-#ifdef PYSCF_USE_MKL
-        mkl_set_num_threads_local(save);
-#endif
 }
 }
 
@@ -253,10 +245,6 @@ void VXC_dcontract_rho(double *rho, double *bra, double *ket,
 {
 #pragma omp parallel
 {
-#ifdef PYSCF_USE_MKL
-        int save = mkl_set_num_threads_local(1);
-#endif
-
         size_t Ngrids = ngrids;
         int nthread = omp_get_num_threads();
         int blksize = MAX((Ngrids+nthread-1) / nthread, 1);
@@ -273,10 +261,6 @@ void VXC_dcontract_rho(double *rho, double *bra, double *ket,
                         rho[j] += bra[i*Ngrids+j] * ket[i*Ngrids+j];
                 } }
         }
-
-#ifdef PYSCF_USE_MKL
-        mkl_set_num_threads_local(save);
-#endif
 }
 }
 
@@ -287,10 +271,6 @@ void VXC_vv10nlc(double *Fvec, double *Uvec, double *Wvec,
 {
 #pragma omp parallel
 {
-#ifdef PYSCF_USE_MKL
-        int save = mkl_set_num_threads_local(1);
-#endif
-
         double DX, DY, DZ, R2;
         double gp, g, gt, T, F, U, W;
         int i, j;
@@ -318,9 +298,6 @@ void VXC_vv10nlc(double *Fvec, double *Uvec, double *Wvec,
                 Wvec[i] = W;
         }
 
-#ifdef PYSCF_USE_MKL
-        mkl_set_num_threads_local(save);
-#endif
 }
 }
 
@@ -330,10 +307,6 @@ void VXC_vv10nlc_grad(double *Fvec, double *vvcoords, double *coords,
 {
 #pragma omp parallel
 {
-#ifdef PYSCF_USE_MKL
-        int save = mkl_set_num_threads_local(1);
-#endif
-
         double DX, DY, DZ, R2;
         double gp, g, gt, T, Q, FX, FY, FZ;
         int i, j;
@@ -361,8 +334,5 @@ void VXC_vv10nlc_grad(double *Fvec, double *vvcoords, double *coords,
                 Fvec[i*3+2] = FZ * -3;
         }
 
-#ifdef PYSCF_USE_MKL
-        mkl_set_num_threads_local(save);
-#endif
 }
 }

--- a/pyscf/lib/dft/nr_numint.c
+++ b/pyscf/lib/dft/nr_numint.c
@@ -24,6 +24,10 @@
 #include "np_helper/np_helper.h"
 #include "vhf/fblas.h"
 
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
+
 #define BOXSIZE         56
 
 int VXCao_empty_blocks(int8_t *empty, uint8_t *non0table, int *shls_slice,
@@ -109,6 +113,10 @@ void VXCdot_ao_dm(double *vm, double *ao, double *dm,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int ip, ib;
 #pragma omp for nowait schedule(static)
         for (ib = 0; ib < nblk; ib++) {
@@ -117,6 +125,10 @@ void VXCdot_ao_dm(double *vm, double *ao, double *dm,
                           nao, nocc, ngrids, MIN(ngrids-ip, BLKSIZE),
                           non0table+ib*nbas, shls_slice, ao_loc);
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -173,8 +185,12 @@ void VXCdot_ao_ao(double *vv, double *ao1, double *ao2,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int ip, ib;
-        double *v_priv = calloc(Nao*Nao+2, sizeof(double));
+        double *v_priv = pyscf_calloc(Nao*Nao+2, sizeof(double));
 #pragma omp for nowait schedule(static)
         for (ib = 0; ib < nblk; ib++) {
                 ip = ib * BLKSIZE;
@@ -188,7 +204,11 @@ void VXCdot_ao_ao(double *vv, double *ao1, double *ao2,
                         vv[ip] += v_priv[ip];
                 }
         }
-        free(v_priv);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+        pyscf_free(v_priv);
 }
         if (hermi != 0) {
                 NPdsymm_triu(nao, vv, hermi);
@@ -201,6 +221,10 @@ void VXC_dscale_ao(double *aow, double *ao, double *wv,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         size_t Ngrids = ngrids;
         size_t ao_size = nao * Ngrids;
         int i, j, ic;
@@ -216,6 +240,10 @@ void VXC_dscale_ao(double *aow, double *ao, double *wv,
                         aow[i*Ngrids+j] += pao[ic*ao_size+j] * wv[ic*Ngrids+j];
                 } }
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -225,6 +253,10 @@ void VXC_dcontract_rho(double *rho, double *bra, double *ket,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         size_t Ngrids = ngrids;
         int nthread = omp_get_num_threads();
         int blksize = MAX((Ngrids+nthread-1) / nthread, 1);
@@ -241,6 +273,10 @@ void VXC_dcontract_rho(double *rho, double *bra, double *ket,
                         rho[j] += bra[i*Ngrids+j] * ket[i*Ngrids+j];
                 } }
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -251,6 +287,10 @@ void VXC_vv10nlc(double *Fvec, double *Uvec, double *Wvec,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         double DX, DY, DZ, R2;
         double gp, g, gt, T, F, U, W;
         int i, j;
@@ -277,6 +317,10 @@ void VXC_vv10nlc(double *Fvec, double *Uvec, double *Wvec,
                 Uvec[i] = U;
                 Wvec[i] = W;
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -286,6 +330,10 @@ void VXC_vv10nlc_grad(double *Fvec, double *vvcoords, double *coords,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         double DX, DY, DZ, R2;
         double gp, g, gt, T, Q, FX, FY, FZ;
         int i, j;
@@ -312,5 +360,9 @@ void VXC_vv10nlc_grad(double *Fvec, double *vvcoords, double *coords,
                 Fvec[i*3+1] = FY * -3;
                 Fvec[i*3+2] = FZ * -3;
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }

--- a/pyscf/lib/dft/nr_numint_sparse.c
+++ b/pyscf/lib/dft/nr_numint_sparse.c
@@ -1152,9 +1152,6 @@ void VXCdscale_ao_sparse(double *aow, double *ao, double *wv,
 {
 #pragma omp parallel
 {
-#ifdef PYSCF_USE_MKL
-        int save = mkl_set_num_threads_local(1);
-#endif
         size_t Ngrids = ngrids;
         size_t ao_size = nao * Ngrids;
         int ish, i, j, ic, i0, i1, ig0, ig1, row;
@@ -1180,8 +1177,5 @@ for (i = i0; i < i1; i++) {
                         }
                 }
         }
-#ifdef PYSCF_USE_MKL
-        mkl_set_num_threads_local(save);
-#endif
 }
 }

--- a/pyscf/lib/dft/nr_numint_sparse.c
+++ b/pyscf/lib/dft/nr_numint_sparse.c
@@ -23,6 +23,10 @@
 #include "cint.h"
 #include "vhf/fblas.h"
 
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
+
 #define ALIGNMENT       8
 #define UNROLL_SIZE     (ALIGNMENT*7)
 #define BLKSIZE         (ALIGNMENT*7)
@@ -229,16 +233,19 @@ void VXCdot_ao_dm_sparse(double *out, double *ao, double *dm,
 {
         size_t Ngrids = ngrids;
         int shls_slice[2] = {0, nbas};
-        int *box_l1_loc = malloc(sizeof(int) * (nbas+1));
+        int *box_l1_loc = pyscf_malloc(sizeof(int) * (nbas+1));
         int nbox_l1 = CVHFshls_block_partition(box_l1_loc, shls_slice, ao_loc, BOXSIZE1_N);
         int mask_l1_size = (ngrids + BOXSIZE1_M - 1)/BOXSIZE1_M * nbox_l1;
-        uint8_t *mask_l1 = malloc(sizeof(uint8_t) * mask_l1_size);
+        uint8_t *mask_l1 = pyscf_malloc(sizeof(uint8_t) * mask_l1_size);
         mask_l1_abstract(mask_l1, screen_index, box_l1_loc, nbox_l1, ngrids, nbas);
         int ngrids_align_down = (ngrids / BLKSIZE) * BLKSIZE;
 
         if (nao * 2 < ngrids) {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
                 int ig, j, j0, j1, jsh0, jsh1, ib, jb, ig0, ig1, ig_box2;
 #pragma omp for schedule(dynamic)
                 for (ig0 = 0; ig0 < ngrids_align_down; ig0+=BOXSIZE1_M) {
@@ -264,10 +271,16 @@ _dot_ao_dm_l1(out, ao, dm, nao, ngrids, nbas, ig0, ig1,
                                 }
                         }
                 }
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
 }
         } else {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
                 int ig, j, j0, j1, jsh0, jsh1, ib, jb, ig0, ig1, ig_box2;
 #pragma omp for schedule(dynamic)
                 for (jb = 0; jb < nbox_l1; jb++) {
@@ -293,14 +306,17 @@ _dot_ao_dm_l1(out, ao, dm, nao, ngrids, nbas, ig0, ig1,
                                 }
                         }
                 }
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
 }
         }
         if (ngrids_align_down < ngrids) {
                 _dot_ao_dm_frac(out, ao, dm, nao, ngrids, nbas, ngrids_align_down,
                                 nbins, screen_index, pair_mask, ao_loc);
         }
-        free(box_l1_loc);
-        free(mask_l1);
+        pyscf_free(box_l1_loc);
+        pyscf_free(mask_l1);
 }
 
 static void _dot_aow_ao_l1(double *out, double *bra, double *ket, double *wv,
@@ -575,8 +591,11 @@ void VXCdot_aow_ao_dense(double *out, double *bra, double *ket, double *wv,
         const double D1 = 1;
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         int i0, ig, i, di, ig0, ig1, dg;
-        double *buf = malloc(sizeof(double) * (ngrids_blksize * nao_blksize + ALIGNMENT));
+        double *buf = pyscf_malloc(sizeof(double) * (ngrids_blksize * nao_blksize + ALIGNMENT));
         double *braw = (double *)((uintptr_t)(buf + ALIGNMENT - 1) & (-(uintptr_t)(ALIGNMENT*8)));
         double *pbra;
 #pragma omp for schedule(dynamic) nowait
@@ -595,7 +614,10 @@ void VXCdot_aow_ao_dense(double *out, double *bra, double *ket, double *wv,
                                &D1, out+i0*Nao, &nao);
                 }
         }
-        free(buf);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+        pyscf_free(buf);
 }
 }
 
@@ -606,20 +628,23 @@ void VXCdot_aow_ao_sparse(double *out, double *bra, double *ket, double *wv,
 {
         size_t Nao = nao;
         int shls_slice[2] = {0, nbas};
-        int *box_l1_loc = malloc(sizeof(int) * (nbas+1));
+        int *box_l1_loc = pyscf_malloc(sizeof(int) * (nbas+1));
         int nbox_l1 = CVHFshls_block_partition(box_l1_loc, shls_slice, ao_loc, BOXSIZE1_N);
         int mask_l1_size = (ngrids + BOXSIZE1_M - 1)/BOXSIZE1_M * nbox_l1;
-        uint8_t *mask_l1 = malloc(sizeof(uint8_t) * mask_l1_size);
+        uint8_t *mask_l1 = pyscf_malloc(sizeof(uint8_t) * mask_l1_size);
         mask_l1_abstract(mask_l1, screen_index, box_l1_loc, nbox_l1, ngrids, nbas);
         int ngrids_align_down = (ngrids / BOXSIZE1_M) * BOXSIZE1_M;
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         int ijb, ib, jb, ib0, jb0, ib1, jb1, ig0, ig1, ig_box2;
         int ish0, ish1, jsh0, jsh1, i0, i1, j0, j1, ni, nj, i, j, n;
         double s;
         double *pout;
-        double *buf = malloc(sizeof(double) * (BOXSIZE1_N*BOXSIZE1_N*ALIGNMENT+ALIGNMENT));
+        double *buf = pyscf_malloc(sizeof(double) * (BOXSIZE1_N*BOXSIZE1_N*ALIGNMENT+ALIGNMENT));
         double *outbuf = (double *)((uintptr_t)(buf+ALIGNMENT-1) & (-(uintptr_t)(ALIGNMENT*sizeof(double))));
 #pragma omp for schedule(dynamic, 4) nowait
         for (ijb = 0; ijb < nbox_l1*nbox_l1; ijb++) {
@@ -673,10 +698,13 @@ _dot_aow_ao_l1(outbuf, bra, ket, wv, nao, ngrids, nbas, ig0, ig1,
                         out[(i0+i)*Nao+j0+j] += s;
                 } }
         }
-        free(buf);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+        pyscf_free(buf);
 }
-        free(box_l1_loc);
-        free(mask_l1);
+        pyscf_free(box_l1_loc);
+        pyscf_free(mask_l1);
 
         if (hermi != 0) {
                 NPdsymm_triu(nao, out, hermi);
@@ -893,21 +921,24 @@ void VXCdot_ao_ao_sparse(double *out, double *bra, double *ket,
 {
         size_t Nao = nao;
         int shls_slice[2] = {0, nbas};
-        int *box_l1_loc = malloc(sizeof(int) * (nbas+1));
+        int *box_l1_loc = pyscf_malloc(sizeof(int) * (nbas+1));
         int nbox_l1 = CVHFshls_block_partition(box_l1_loc, shls_slice, ao_loc, BOXSIZE1_N);
         int mask_l1_size = (ngrids + BOXSIZE1_M - 1)/BOXSIZE1_M * nbox_l1;
-        uint8_t *mask_l1 = malloc(sizeof(uint8_t) * mask_l1_size);
+        uint8_t *mask_l1 = pyscf_malloc(sizeof(uint8_t) * mask_l1_size);
         mask_l1_abstract(mask_l1, screen_index, box_l1_loc,
                          nbox_l1, ngrids, nbas);
         int ngrids_align_down = (ngrids / BOXSIZE1_M) * BOXSIZE1_M;
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         int ijb, ib, jb, ib0, jb0, ib1, jb1, ig0, ig1, ig_box2;
         int ish0, ish1, jsh0, jsh1, i0, i1, j0, j1, ni, nj, i, j, n;
         double s;
         double *pout;
-        double *buf = malloc(sizeof(double) * (BOXSIZE1_N*BOXSIZE1_N*ALIGNMENT+ALIGNMENT));
+        double *buf = pyscf_malloc(sizeof(double) * (BOXSIZE1_N*BOXSIZE1_N*ALIGNMENT+ALIGNMENT));
         double *outbuf = (double *)((uintptr_t)(buf+ALIGNMENT-1) & (-(uintptr_t)(ALIGNMENT*sizeof(double))));
 #pragma omp for schedule(dynamic, 4) nowait
         for (ijb = 0; ijb < nbox_l1*nbox_l1; ijb++) {
@@ -961,10 +992,13 @@ _dot_ao_ao_l1(outbuf, bra, ket, nao, ngrids, nbas, ig0, ig1,
                         out[(i0+i)*Nao+j0+j] += s;
                 } }
         }
-        free(buf);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
+        pyscf_free(buf);
 }
-        free(box_l1_loc);
-        free(mask_l1);
+        pyscf_free(box_l1_loc);
+        pyscf_free(mask_l1);
 
         if (hermi != 0) {
                 NPdsymm_triu(nao, out, hermi);
@@ -984,6 +1018,9 @@ void VXCdcontract_rho_sparse(double *rho, double *bra, double *ket,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
                 size_t Ngrids = ngrids;
                 size_t i_addr;
                 int ig0, row, ish, i0, i1, n, i;
@@ -1010,6 +1047,9 @@ void VXCdcontract_rho_sparse(double *rho, double *bra, double *ket,
                                 rho[ig0+n] = s8[n];
                         }
                 }
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
 }
                 if (ngrids_align_down < ngrids) {
                         size_t Ngrids = ngrids;
@@ -1043,13 +1083,16 @@ void VXCdcontract_rho_sparse(double *rho, double *bra, double *ket,
                 rhobufs[0] = rho;
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
                 size_t Ngrids = ngrids;
                 size_t i_addr;
                 int ig0, row, ish, i0, i1, n, i;
                 double s8[BLKSIZE];
                 int thread_id = omp_get_thread_num();
                 if (thread_id > 0) {
-                        rhobufs[thread_id] = malloc(sizeof(double) * ngrids);
+                        rhobufs[thread_id] = pyscf_malloc(sizeof(double) * ngrids);
                 }
                 double *rho_priv = rhobufs[thread_id];
                 NPdset0(rho_priv, ngrids);
@@ -1093,8 +1136,11 @@ void VXCdcontract_rho_sparse(double *rho, double *bra, double *ket,
                 }
                 NPomp_dsum_reduce_inplace(rhobufs, ngrids);
                 if (thread_id > 0) {
-                        free(rho_priv);
+                        pyscf_free(rho_priv);
                 }
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
 }
         }  // if (nao * 2 < ngrids)
 }
@@ -1106,6 +1152,9 @@ void VXCdscale_ao_sparse(double *aow, double *ao, double *wv,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         size_t Ngrids = ngrids;
         size_t ao_size = nao * Ngrids;
         int ish, i, j, ic, i0, i1, ig0, ig1, row;
@@ -1131,5 +1180,8 @@ for (i = i0; i < i1; i++) {
                         }
                 }
         }
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }

--- a/pyscf/lib/gto/fill_grids_int2c.c
+++ b/pyscf/lib/gto/fill_grids_int2c.c
@@ -80,10 +80,14 @@ void GTOgrids_int2c(int (*intor)(), double *mat, int comp, int hermi,
         const int dims[] = {naoi, naoj, ngrids};
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         size_t ij;
         int ish, jsh, i0, j0, grid0, grid1;
         int shls[4];
-        double *cache = malloc(sizeof(double) * cache_size);
+        double *cache = pyscf_malloc(sizeof(double) * cache_size);
 #pragma omp for schedule(dynamic, 1)
         for (ij = 0; ij < nish*njsh; ij++) {
                 ish = ij / njsh;
@@ -107,7 +111,7 @@ void GTOgrids_int2c(int (*intor)(), double *mat, int comp, int hermi,
                                  atm, natm, bas, nbas, env, opt, cache);
                 }
         }
-        free(cache);
+        pyscf_free(cache);
 
         if (hermi != PLAIN) { // lower triangle of F-array
                 size_t ic, i, j, ig;
@@ -137,6 +141,10 @@ void GTOgrids_int2c(int (*intor)(), double *mat, int comp, int hermi,
                         }
                 }
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -158,10 +166,14 @@ void GTOgrids_int2c_spinor(int (*intor)(), double complex *mat, int comp, int he
         int dims[] = {naoi, naoj, ngrids};
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         size_t ij;
         int ish, jsh, i0, j0, grid0, grid1;
         int shls[4];
-        double *cache = malloc(sizeof(double) * cache_size);
+        double *cache = pyscf_malloc(sizeof(double) * cache_size);
 #pragma omp for schedule(dynamic, 1)
         for (ij = 0; ij < nish*njsh; ij++) {
                 ish = ij / njsh;
@@ -184,7 +196,7 @@ void GTOgrids_int2c_spinor(int (*intor)(), double complex *mat, int comp, int he
                                  atm, natm, bas, nbas, env, opt, cache);
                 }
         }
-        free(cache);
+        pyscf_free(cache);
 
         if (hermi != PLAIN) { // lower triangle of F-array
                 size_t ic, i, j, ig;
@@ -218,5 +230,9 @@ void GTOgrids_int2c_spinor(int (*intor)(), double complex *mat, int comp, int he
                         }
                 }
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }

--- a/pyscf/lib/gto/fill_nr_3c.c
+++ b/pyscf/lib/gto/fill_nr_3c.c
@@ -213,14 +213,22 @@ void GTOnr3c_drv(int (*intor)(), void (*fill)(), double *eri, int comp,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int jobid;
-        double *buf = malloc(sizeof(double) * (di*di*di*comp + cache_size));
+        double *buf = pyscf_malloc(sizeof(double) * (di*di*di*comp + cache_size));
 #pragma omp for nowait schedule(dynamic)
         for (jobid = 0; jobid < njobs; jobid++) {
                 (*fill)(intor, eri, buf, comp, jobid, shls_slice, ao_loc,
                         cintopt, atm, natm, bas, nbas, env);
         }
-        free(buf);
+        pyscf_free(buf);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 

--- a/pyscf/lib/gto/ft_ao.h
+++ b/pyscf/lib/gto/ft_ao.h
@@ -46,7 +46,7 @@ typedef struct {
         int lj_ceil;
         int g_stride_i;
         int g_stride_j;
-        int g_size;  // ref to cint2e.c g = malloc(sizeof(double)*g_size)
+        int g_size;  // ref to cint2e.c g = pyscf_malloc(sizeof(double)*g_size)
         double expcutoff;
         double ai[1];
         double aj[1];

--- a/pyscf/lib/gto/grid_ao_drv.c
+++ b/pyscf/lib/gto/grid_ao_drv.c
@@ -204,22 +204,31 @@ static void _fill_grid2atm(double *grid2atm, double *coord, size_t bgrids, size_
 
 static void _dset0(double *out, size_t odim, size_t bgrids, int counts)
 {
+#ifndef PYSCF_USE_MKL
         size_t i, j;
         for (i = 0; i < counts; i++) {
                 for (j = 0; j < bgrids; j++) {
                         out[i*odim+j] = 0;
                 }
         }
+#else
+        LAPACKE_dlaset(LAPACK_ROW_MAJOR, 'A', counts, bgrids, 0.0, 0.0, out, odim);
+#endif
 }
 
 static void _zset0(double complex *out, size_t odim, size_t bgrids, int counts)
 {
+#ifndef PYSCF_USE_MKL
         size_t i, j;
         for (i = 0; i < counts; i++) {
                 for (j = 0; j < bgrids; j++) {
                         out[i*odim+j] = 0;
                 }
         }
+#else
+        MKL_Complex16 zero = {0.0, 0.0};
+        LAPACKE_zlaset(LAPACK_ROW_MAJOR, 'A', counts, bgrids, zero, zero, (MKL_Complex16*) out, odim);
+#endif
 }
 
 void GTOeval_sph_iter(FPtr_eval feval,  FPtr_exp fexp, double fac,

--- a/pyscf/lib/gto/nr_ecp.c
+++ b/pyscf/lib/gto/nr_ecp.c
@@ -6198,7 +6198,7 @@ int ECPscalar_sph(double *out, int *dims, int *shls, int *atm, int natm,
         if (cache == NULL) {
                 int cache_size = ECPscalar_cache_size(comp, shls,
                                                       atm, natm, bas, nbas, env);
-                stack = malloc(sizeof(double) * cache_size);
+                stack = pyscf_malloc(sizeof(double) * cache_size);
                 cache = stack;
         }
 
@@ -6215,7 +6215,7 @@ int ECPscalar_sph(double *out, int *dims, int *shls, int *atm, int natm,
         }
 
         if (stack != NULL) {
-                free(stack);
+                pyscf_free(stack);
         }
         return has_value;
 }
@@ -6241,7 +6241,7 @@ int ECPscalar_cart(double *out, int *dims, int *shls, int *atm, int natm,
         if (cache == NULL) {
                 int cache_size = ECPscalar_cache_size(comp, shls,
                                                       atm, natm, bas, nbas, env);
-                stack = malloc(sizeof(double) * cache_size);
+                stack = pyscf_malloc(sizeof(double) * cache_size);
                 cache = stack;
         }
 
@@ -6260,7 +6260,7 @@ int ECPscalar_cart(double *out, int *dims, int *shls, int *atm, int natm,
         }
 
         if (stack != NULL) {
-                free(stack);
+                pyscf_free(stack);
         }
         return has_value;
 }
@@ -6344,7 +6344,7 @@ static void cart2spinor(double complex *opij, double *gctr, int *dims,
 
 void ECPscalar_optimizer(ECPOpt **opt, int *atm, int natm, int *bas, int nbas, double *env)
 {
-        ECPOpt *opt0 = (ECPOpt *)malloc(sizeof(ECPOpt));
+        ECPOpt *opt0 = (ECPOpt *)pyscf_malloc(sizeof(ECPOpt));
         *opt = opt0;
 
         int *ecpbas = bas + (int)(env[AS_ECPBAS_OFFSET])*BAS_SLOTS;
@@ -6355,7 +6355,7 @@ void ECPscalar_optimizer(ECPOpt **opt, int *atm, int natm, int *bas, int nbas, d
         int npk;
         int i, ib, kp;
 
-        opt0->u_ecp = malloc(sizeof(double) * (1 << LEVEL_MAX) * necpbas);
+        opt0->u_ecp = pyscf_malloc(sizeof(double) * (1 << LEVEL_MAX) * necpbas);
         uk = opt0->u_ecp;
         for (ib = 0; ib < necpbas; ib++) {
                 npk = ecpbas[ib*BAS_SLOTS+NPRIM_OF];
@@ -6386,9 +6386,9 @@ void ECPdel_optimizer(ECPOpt **opt)
         }
 
         if (opt0->u_ecp != NULL) {
-                free(opt0->u_ecp);
+                pyscf_free(opt0->u_ecp);
         }
-        free(opt0);
+        pyscf_free(opt0);
         opt = NULL;
 }
 
@@ -6419,7 +6419,7 @@ int ECPso_cart(double *out, int *dims, int *shls, int *atm, int natm,
         if (cache == NULL) {
                 int cache_size = ECPscalar_cache_size(comp, shls,
                                                       atm, natm, bas, nbas, env);
-                stack = malloc(sizeof(double) * cache_size);
+                stack = pyscf_malloc(sizeof(double) * cache_size);
                 cache = stack;
         }
 
@@ -6440,7 +6440,7 @@ int ECPso_cart(double *out, int *dims, int *shls, int *atm, int natm,
         }
 
         if (stack != NULL) {
-                free(stack);
+                pyscf_free(stack);
         }
         return has_value;
 }
@@ -6468,7 +6468,7 @@ int ECPso_sph(double *out, int *dims, int *shls, int *atm, int natm,
         if (cache == NULL) {
                 int cache_size = ECPscalar_cache_size(comp, shls,
                                                       atm, natm, bas, nbas, env);
-                stack = malloc(sizeof(double) * cache_size);
+                stack = pyscf_malloc(sizeof(double) * cache_size);
                 cache = stack;
         }
 
@@ -6487,7 +6487,7 @@ int ECPso_sph(double *out, int *dims, int *shls, int *atm, int natm,
         }
 
         if (stack != NULL) {
-                free(stack);
+                pyscf_free(stack);
         }
         return has_value;
 }
@@ -6518,7 +6518,7 @@ int ECPso_spinor(double complex *out, int *dims, int *shls, int *atm, int natm,
         if (cache == NULL) {
                 int cache_size = ECPscalar_cache_size(comp, shls,
                                                       atm, natm, bas, nbas, env);
-                stack = malloc(sizeof(double) * (cache_size + ngctr*8*OF_CMPLX));
+                stack = pyscf_malloc(sizeof(double) * (cache_size + ngctr*8*OF_CMPLX));
                 cache = stack;
         }
 
@@ -6537,7 +6537,7 @@ int ECPso_spinor(double complex *out, int *dims, int *shls, int *atm, int natm,
         cart2spinor(out, buf1, dims, shls, bas, cache);
 
         if (stack != NULL) {
-                free(stack);
+                pyscf_free(stack);
         }
         return has_value;
 }

--- a/pyscf/lib/gto/nr_ecp_deriv.c
+++ b/pyscf/lib/gto/nr_ecp_deriv.c
@@ -307,7 +307,7 @@ static int _cart_factory(Function_cart intor_cart, double *out, int comp,
         if (cache == NULL) {
                 int cache_size = ECPscalar_cache_size(comp*2, shls,
                                                       atm, natm, bas, nbas, env);
-                stack = malloc(sizeof(double) * cache_size);
+                stack = pyscf_malloc(sizeof(double) * cache_size);
                 cache = stack;
         }
 
@@ -325,7 +325,7 @@ static int _cart_factory(Function_cart intor_cart, double *out, int comp,
         }
 
         if (stack != NULL) {
-                free(stack);
+                pyscf_free(stack);
         }
         return has_value;
 }
@@ -396,7 +396,7 @@ static int _sph_factory(Function_cart intor_cart, double *out, int comp,
         if (cache == NULL) {
                 int cache_size = ECPscalar_cache_size(comp*2+2, shls,
                                                       atm, natm, bas, nbas, env);
-                stack = malloc(sizeof(double) * cache_size);
+                stack = pyscf_malloc(sizeof(double) * cache_size);
                 cache = stack;
         }
 
@@ -412,7 +412,7 @@ static int _sph_factory(Function_cart intor_cart, double *out, int comp,
         }
 
         if (stack != NULL) {
-                free(stack);
+                pyscf_free(stack);
         }
         return has_value;
 }

--- a/pyscf/lib/mcscf/fci_contract.c
+++ b/pyscf/lib/mcscf/fci_contract.c
@@ -194,7 +194,7 @@ void FCIcontract_a_1e(double *f1e_tril, double *ci0, double *ci1,
         double *pci0, *pci1;
         double tmp;
         _LinkTrilT *tab;
-        _LinkTrilT *clink = malloc(sizeof(_LinkTrilT) * nlinka * nstra);
+        _LinkTrilT *clink = pyscf_malloc(sizeof(_LinkTrilT) * nlinka * nstra);
         FCIcompress_link_tril(clink, link_indexa, nstra, nlinka);
 
         for (str0 = 0; str0 < nstra; str0++) {
@@ -211,7 +211,7 @@ void FCIcontract_a_1e(double *f1e_tril, double *ci0, double *ci1,
                         }
                 }
         }
-        free(clink);
+        pyscf_free(clink);
 }
 
 /*
@@ -226,7 +226,7 @@ void FCIcontract_b_1e(double *f1e_tril, double *ci0, double *ci1,
         double *pci1;
         double tmp;
         _LinkTrilT *tab;
-        _LinkTrilT *clink = malloc(sizeof(_LinkTrilT) * nlinkb * nstrb);
+        _LinkTrilT *clink = pyscf_malloc(sizeof(_LinkTrilT) * nlinkb * nstrb);
         FCIcompress_link_tril(clink, link_indexb, nstrb, nlinkb);
 
         for (str0 = 0; str0 < nstra; str0++) {
@@ -242,7 +242,7 @@ void FCIcontract_b_1e(double *f1e_tril, double *ci0, double *ci1,
                         }
                 }
         }
-        free(clink);
+        pyscf_free(clink);
 }
 
 void FCIcontract_1e_spin0(double *f1e_tril, double *ci0, double *ci1,
@@ -358,21 +358,25 @@ static void _reduce(double *out, double **in, size_t count, size_t no, size_t ni
 void FCIcontract_2e_spin0(double *eri, double *ci0, double *ci1,
                           int norb, int na, int nlink, int *link_index)
 {
-        _LinkTrilT *clink = malloc(sizeof(_LinkTrilT) * nlink * na);
+        _LinkTrilT *clink = pyscf_malloc(sizeof(_LinkTrilT) * nlink * na);
         FCIcompress_link_tril(clink, link_index, na, nlink);
 
         NPdset0(ci1, ((size_t)na) * na);
         double *ci1bufs[MAX_THREADS];
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int strk, ib;
         size_t blen;
         int nnorb = norb*(norb+1)/2;
-        double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*nnorb*2+2));
+        double *t1buf = pyscf_malloc(sizeof(double) * (STRB_BLKSIZE*nnorb*2+2));
         double *tmp;
         double *t1 = t1buf;
         double *vt1 = t1buf + nnorb*STRB_BLKSIZE;
-        double *ci1buf = malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
+        double *ci1buf = pyscf_malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
         ci1bufs[omp_get_thread_num()] = ci1buf;
         for (ib = 0; ib < na; ib += STRB_BLKSIZE) {
                 blen = MIN(STRB_BLKSIZE, na-ib);
@@ -396,10 +400,14 @@ void FCIcontract_2e_spin0(double *eri, double *ci0, double *ci1,
 // occur race condition between FCIaxpy2d and ctr_rhf2e_kern
 #pragma omp barrier
         }
-        free(ci1buf);
-        free(t1buf);
+        pyscf_free(ci1buf);
+        pyscf_free(t1buf);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(clink);
+        pyscf_free(clink);
 }
 
 
@@ -407,8 +415,8 @@ void FCIcontract_2e_spin1(double *eri, double *ci0, double *ci1,
                           int norb, int na, int nb, int nlinka, int nlinkb,
                           int *link_indexa, int *link_indexb)
 {
-        _LinkTrilT *clinka = malloc(sizeof(_LinkTrilT) * nlinka * na);
-        _LinkTrilT *clinkb = malloc(sizeof(_LinkTrilT) * nlinkb * nb);
+        _LinkTrilT *clinka = pyscf_malloc(sizeof(_LinkTrilT) * nlinka * na);
+        _LinkTrilT *clinkb = pyscf_malloc(sizeof(_LinkTrilT) * nlinkb * nb);
         FCIcompress_link_tril(clinka, link_indexa, na, nlinka);
         FCIcompress_link_tril(clinkb, link_indexb, nb, nlinkb);
 
@@ -416,14 +424,18 @@ void FCIcontract_2e_spin1(double *eri, double *ci0, double *ci1,
         double *ci1bufs[MAX_THREADS];
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int strk, ib;
         size_t blen;
         int nnorb = norb*(norb+1)/2;
-        double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*nnorb*2+2));
+        double *t1buf = pyscf_malloc(sizeof(double) * (STRB_BLKSIZE*nnorb*2+2));
         double *tmp;
         double *t1 = t1buf;
         double *vt1 = t1buf + nnorb*STRB_BLKSIZE;
-        double *ci1buf = malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
+        double *ci1buf = pyscf_malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
         ci1bufs[omp_get_thread_num()] = ci1buf;
         for (ib = 0; ib < nb; ib += STRB_BLKSIZE) {
                 blen = MIN(STRB_BLKSIZE, nb-ib);
@@ -445,11 +457,15 @@ void FCIcontract_2e_spin1(double *eri, double *ci0, double *ci1,
 // occur race condition between FCIaxpy2d and ctr_rhf2e_kern
 #pragma omp barrier
         }
-        free(ci1buf);
-        free(t1buf);
+        pyscf_free(ci1buf);
+        pyscf_free(t1buf);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(clinka);
-        free(clinkb);
+        pyscf_free(clinka);
+        pyscf_free(clinkb);
 }
 
 
@@ -501,8 +517,8 @@ void FCIcontract_uhf2e(double *eri_aa, double *eri_ab, double *eri_bb,
                        int norb, int na, int nb, int nlinka, int nlinkb,
                        int *link_indexa, int *link_indexb)
 {
-        _LinkTrilT *clinka = malloc(sizeof(_LinkTrilT) * nlinka * na);
-        _LinkTrilT *clinkb = malloc(sizeof(_LinkTrilT) * nlinkb * nb);
+        _LinkTrilT *clinka = pyscf_malloc(sizeof(_LinkTrilT) * nlinka * na);
+        _LinkTrilT *clinkb = pyscf_malloc(sizeof(_LinkTrilT) * nlinkb * nb);
         FCIcompress_link_tril(clinka, link_indexa, na, nlinka);
         FCIcompress_link_tril(clinkb, link_indexb, nb, nlinkb);
 
@@ -510,10 +526,14 @@ void FCIcontract_uhf2e(double *eri_aa, double *eri_ab, double *eri_bb,
         double *ci1bufs[MAX_THREADS];
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int strk, ib;
         size_t blen;
-        double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)*2+2));
-        double *ci1buf = malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
+        double *t1buf = pyscf_malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)*2+2));
+        double *ci1buf = pyscf_malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
         ci1bufs[omp_get_thread_num()] = ci1buf;
         for (ib = 0; ib < nb; ib += STRB_BLKSIZE) {
                 blen = MIN(STRB_BLKSIZE, nb-ib);
@@ -534,11 +554,15 @@ void FCIcontract_uhf2e(double *eri_aa, double *eri_ab, double *eri_bb,
 // occur race condition between FCIaxpy2d and ctr_uhf2e_kern
 #pragma omp barrier
         }
-        free(t1buf);
-        free(ci1buf);
+        pyscf_free(t1buf);
+        pyscf_free(ci1buf);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(clinka);
-        free(clinkb);
+        pyscf_free(clinka);
+        pyscf_free(clinkb);
 }
 
 
@@ -555,6 +579,10 @@ void FCImake_hdiag_uhf(double *hdiag, double *h1e_a, double *h1e_b,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int j, j0, k0, jk, jk0;
         size_t ia, ib;
         double e1, e2;
@@ -591,6 +619,10 @@ void FCImake_hdiag_uhf(double *hdiag, double *h1e_a, double *h1e_b,
                         hdiag[ia*nstrb+ib] = e1 + e2 * .5;
                 }
         }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -634,6 +666,10 @@ void FCIpspace_h0tril_uhf(double *h0, double *h1e_a, double *h1e_b,
         const int d3 = norb * norb * norb;
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         int i, j, k, pi, pj, pk, pl;
         int n1da, n1db;
         uint64_t da, db, str1;
@@ -729,6 +765,10 @@ void FCIpspace_h0tril_uhf(double *h0, double *h1e_a, double *h1e_b,
                         } break;
                 }
         } }
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -864,7 +904,7 @@ void FCIcontract_2e_symm1(double *eris, double *ci0, double *ci1,
         int i;
         int na = 0;
         int nb = 0;
-        int *linka_loc = malloc(sizeof(int) * (nirreps*4+4));
+        int *linka_loc = pyscf_malloc(sizeof(int) * (nirreps*4+4));
         int *linkb_loc = linka_loc + nirreps + 1;
         int *eris_loc = linkb_loc + nirreps + 1;
         int *ci_loc = eris_loc + nirreps + 1;
@@ -884,10 +924,14 @@ void FCIcontract_2e_symm1(double *eris, double *ci0, double *ci1,
         double *ci1bufs[MAX_THREADS];
 #pragma omp parallel
 {
-        _LinkTrilT *clinka = malloc(sizeof(_LinkTrilT) * nlinka * na);
-        _LinkTrilT *clinkb = malloc(sizeof(_LinkTrilT) * nlinkb * nb);
-        double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)+2));
-        double *ci1buf = malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
+        _LinkTrilT *clinka = pyscf_malloc(sizeof(_LinkTrilT) * nlinka * na);
+        _LinkTrilT *clinkb = pyscf_malloc(sizeof(_LinkTrilT) * nlinkb * nb);
+        double *t1buf = pyscf_malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)+2));
+        double *ci1buf = pyscf_malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
         ci1bufs[omp_get_thread_num()] = ci1buf;
 
         int ai_ir, t1_ir, intera_ir, interb_ir, stra_ir, strb_ir;
@@ -913,12 +957,16 @@ loop_c2e_symm(eris+eris_loc[ai_ir],
                         }
                 }
         } }
-        free(ci1buf);
-        free(t1buf);
-        free(clinka);
-        free(clinkb);
+        pyscf_free(ci1buf);
+        pyscf_free(t1buf);
+        pyscf_free(clinka);
+        pyscf_free(clinkb);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(linka_loc);
+        pyscf_free(linka_loc);
 }
 
 #define IRREP_OF(l, g)  (l + max_momentum + (g) * ug_offsets)
@@ -934,7 +982,7 @@ void FCIcontract_2e_cyl_sym(double *eris, double *ci0, double *ci1,
         int i;
         int na = 0;
         int nb = 0;
-        int *linka_loc = malloc(sizeof(int) * (nirreps*4+4));
+        int *linka_loc = pyscf_malloc(sizeof(int) * (nirreps*4+4));
         int *linkb_loc = linka_loc + nirreps + 1;
         int *ci_loc = linkb_loc + nirreps + 1;
         int *eris_loc = ci_loc + nirreps + 1;
@@ -954,10 +1002,14 @@ void FCIcontract_2e_cyl_sym(double *eris, double *ci0, double *ci1,
         double *ci1bufs[MAX_THREADS];
 #pragma omp parallel
 {
-        _LinkTrilT *clinka = malloc(sizeof(_LinkTrilT) * nlinka * na);
-        _LinkTrilT *clinkb = malloc(sizeof(_LinkTrilT) * nlinkb * nb);
-        double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)+2));
-        double *ci1buf = malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
+        _LinkTrilT *clinka = pyscf_malloc(sizeof(_LinkTrilT) * nlinka * na);
+        _LinkTrilT *clinkb = pyscf_malloc(sizeof(_LinkTrilT) * nlinkb * nb);
+        double *t1buf = pyscf_malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)+2));
+        double *ci1buf = pyscf_malloc(sizeof(double) * (na*STRB_BLKSIZE+2));
         ci1bufs[omp_get_thread_num()] = ci1buf;
 
         int stra_l, strb_l, stra_g, strb_g;
@@ -1018,10 +1070,14 @@ loop_c2e_symm(eris+eris_loc[ai_ir],
                         } }
                 }
         } }
-        free(ci1buf);
-        free(t1buf);
-        free(clinka);
-        free(clinkb);
+        pyscf_free(ci1buf);
+        pyscf_free(t1buf);
+        pyscf_free(clinka);
+        pyscf_free(clinkb);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(linka_loc);
+        pyscf_free(linka_loc);
 }

--- a/pyscf/lib/np_helper/np_helper.c
+++ b/pyscf/lib/np_helper/np_helper.c
@@ -15,6 +15,9 @@
 
 #include <stdlib.h>
 #include "np_helper/np_helper.h"
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
 
 void NPdset0(double *p, const size_t n)
 {
@@ -46,4 +49,31 @@ void NPzcopy(double complex *out, const double complex *in, const size_t n)
         for (i = 0; i < n; i++) {
                 out[i] = in[i];
         }
+}
+
+void* pyscf_malloc(size_t alloc_size)
+{
+#ifdef PYSCF_USE_MKL
+        return mkl_malloc(alloc_size, 64);
+#else
+        return malloc(alloc_size);
+#endif
+}
+
+void *pyscf_calloc(size_t n, size_t size)
+{
+#ifdef PYSCF_USE_MKL
+        return mkl_calloc(n, size, 64);
+#else
+        return calloc(n, size);
+#endif
+}
+
+void pyscf_free(void *ptr)
+{
+#ifdef PYSCF_USE_MKL
+        mkl_free(ptr);
+#else
+        free(ptr);
+#endif
 }

--- a/pyscf/lib/np_helper/np_helper.c
+++ b/pyscf/lib/np_helper/np_helper.c
@@ -51,42 +51,6 @@ void NPzcopy(double complex *out, const double complex *in, const size_t n)
         }
 }
 
-void* pyscf_malloc(size_t alloc_size)
-{
-#ifdef PYSCF_USE_MKL
-        return mkl_malloc(alloc_size, 64);
-#else
-        return malloc(alloc_size);
-#endif
-}
-
-void *pyscf_calloc(size_t n, size_t size)
-{
-#ifdef PYSCF_USE_MKL
-        return mkl_calloc(n, size, 64);
-#else
-        return calloc(n, size);
-#endif
-}
-
-void pyscf_free(void *ptr)
-{
-#ifdef PYSCF_USE_MKL
-        mkl_free(ptr);
-#else
-        free(ptr);
-#endif
-}
-
-void *pyscf_realloc(void *ptr, size_t size)
-{
-#ifdef PYSCF_USE_MKL
-        return mkl_realloc(ptr, size);
-#else
-        return realloc(ptr, size);
-#endif
-}
-
 int pyscf_has_mkl(void) {
 #ifdef PYSCF_USE_MKL
         return 1;

--- a/pyscf/lib/np_helper/np_helper.c
+++ b/pyscf/lib/np_helper/np_helper.c
@@ -77,3 +77,11 @@ void pyscf_free(void *ptr)
         free(ptr);
 #endif
 }
+
+int pyscf_has_mkl(void) {
+#ifdef PYSCF_USE_MKL
+        return 1;
+#else
+        return 0;
+#endif
+}

--- a/pyscf/lib/np_helper/np_helper.c
+++ b/pyscf/lib/np_helper/np_helper.c
@@ -78,10 +78,69 @@ void pyscf_free(void *ptr)
 #endif
 }
 
+void *pyscf_realloc(void *ptr, size_t size)
+{
+#ifdef PYSCF_USE_MKL
+        return mkl_realloc(ptr, size);
+#else
+        return realloc(ptr, size);
+#endif
+}
+
 int pyscf_has_mkl(void) {
 #ifdef PYSCF_USE_MKL
         return 1;
 #else
         return 0;
+#endif
+}
+
+void NPomp_dset0(double *p, const size_t n)
+{
+#ifndef PYSCF_USE_MKL
+#pragma omp parallel for
+        for (size_t i = 0; i < n; i++) {
+                p[i] = 0;
+        }
+#else
+        LAPACKE_dlaset(LAPACK_COL_MAJOR, 'A', n, 1, 0.0, 0.0, p, n);
+#endif
+}
+
+void NPomp_zset0(double complex *p, const size_t n)
+{
+#ifndef PYSCF_USE_MKL
+#pragma omp parallel for
+        for (size_t i = 0; i < n; i++) {
+                p[i] = 0;
+        }
+#else
+        MKL_Complex16 zero = {0.0, 0.0};
+        LAPACKE_zlaset(LAPACK_COL_MAJOR, 'A', n, 1, zero, zero, (MKL_Complex16*) p, n);
+#endif
+}
+
+void NPomp_dmul(double *A, double *B, double *out, size_t n)
+{
+#ifndef PYSCF_USE_MKL
+#pragma omp parallel for
+        for (size_t i = 0; i < n; i++) {
+                out[i] = A[i] * B[i];
+        }
+#else
+        vdMul(n, A, B, out);
+#endif
+}
+
+void NPomp_zmul(double complex *A, double complex *B, double complex *out, size_t n)
+{
+#ifndef PYSCF_USE_MKL
+        size_t i;
+#pragma omp parallel for
+        for (size_t i = 0; i < n; i++) {
+                out[i] = A[i] * B[i];
+        }
+#else
+        vzMul(n, (MKL_Complex16*) A, (MKL_Complex16*) B, (MKL_Complex16*) out);
 #endif
 }

--- a/pyscf/lib/np_helper/np_helper.h
+++ b/pyscf/lib/np_helper/np_helper.h
@@ -36,6 +36,20 @@
                 for (I = 0, j1 = MIN(j0+BLOCK_DIM, n); I < j1; I++) \
                         for (J = MAX(I,j0); J < j1; J++)
 
+#ifdef PYSCF_USE_MKL
+#define pyscf_malloc(SZ) mkl_malloc((SZ), 64)
+#define pyscf_free mkl_free
+#define pyscf_calloc(n, SZ) mkl_calloc((n), (SZ), 64)
+#define pyscf_realloc mkl_realloc
+
+#else
+
+#define pyscf_malloc malloc
+#define pyscf_free free
+#define pyscf_calloc calloc
+#define pyscf_realloc realloc
+#endif
+
 void NPdsymm_triu(int n, double *mat, int hermi);
 void NPzhermi_triu(int n, double complex *mat, int hermi);
 void NPdunpack_tril(int n, double *tril, double *mat, int hermi);
@@ -78,8 +92,4 @@ void NPdgemm(const char trans_a, const char trans_b,
              double *a, double *b, double *c,
              const double alpha, const double beta);
 
-void *pyscf_malloc(size_t alloc_size);
-void *pyscf_calloc(size_t n, size_t size);
-void *pyscf_realloc(void *ptr, size_t size);
-void pyscf_free(void *ptr);
 int pyscf_has_mkl(void);

--- a/pyscf/lib/np_helper/np_helper.h
+++ b/pyscf/lib/np_helper/np_helper.h
@@ -76,3 +76,4 @@ void NPdgemm(const char trans_a, const char trans_b,
 void *pyscf_malloc(size_t alloc_size);
 void *pyscf_calloc(size_t n, size_t size);
 void pyscf_free(void *ptr);
+int pyscf_has_mkl(void);

--- a/pyscf/lib/np_helper/np_helper.h
+++ b/pyscf/lib/np_helper/np_helper.h
@@ -66,6 +66,11 @@ void NPzset0(double complex *p, const size_t n);
 void NPdcopy(double *out, const double *in, const size_t n);
 void NPzcopy(double complex *out, const double complex *in, const size_t n);
 
+void NPomp_dset0(double *p, const size_t n);
+void NPomp_zset0(double complex *p, const size_t n);
+void NPomp_dmul(double *A, double *B, double *out, size_t n);
+void NPomp_zmul(double complex *A, double complex *B, double complex *out, size_t n);
+
 void NPdgemm(const char trans_a, const char trans_b,
              const int m, const int n, const int k,
              const int lda, const int ldb, const int ldc,
@@ -75,5 +80,6 @@ void NPdgemm(const char trans_a, const char trans_b,
 
 void *pyscf_malloc(size_t alloc_size);
 void *pyscf_calloc(size_t n, size_t size);
+void *pyscf_realloc(void *ptr, size_t size);
 void pyscf_free(void *ptr);
 int pyscf_has_mkl(void);

--- a/pyscf/lib/np_helper/np_helper.h
+++ b/pyscf/lib/np_helper/np_helper.h
@@ -18,6 +18,10 @@
 
 #include <complex.h>
 
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
+
 #define BLOCK_DIM    104
 
 #define HERMITIAN    1
@@ -68,3 +72,7 @@ void NPdgemm(const char trans_a, const char trans_b,
              const int offseta, const int offsetb, const int offsetc,
              double *a, double *b, double *c,
              const double alpha, const double beta);
+
+void *pyscf_malloc(size_t alloc_size);
+void *pyscf_calloc(size_t n, size_t size);
+void pyscf_free(void *ptr);

--- a/pyscf/lib/np_helper/omp_reduce.c
+++ b/pyscf/lib/np_helper/omp_reduce.c
@@ -20,6 +20,10 @@
 #include <complex.h>
 #include "config.h"
 
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
+
 #define MIN(x, y)       ((x) < (y) ? (x) : (y))
 
 void NPomp_split(size_t *start, size_t *end, size_t n) {

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -1406,6 +1406,20 @@ def isin_1d(v, vs, return_index=False):
             idx = idx[0]
         return v_in_vs, idx
 
+def pyscf_has_mkl():
+    '''Check if PySCF is linked directly with Intel MKL
+
+    Returns:
+        bool : True if PySCF has been built with MKL, False otherwise.
+    '''
+
+    fn = _np_helper.pyscf_has_mkl
+    fn.restype = ctypes.c_int
+    fn.argtypes = []
+    if fn() == 1:
+        return True
+    return False
+
 if __name__ == '__main__':
     a = numpy.random.random((30,40,5,10))
     b = numpy.random.random((10,30,5,20))

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -1092,6 +1092,24 @@ def condense(opname, a, loc_x, loc_y=None):
         out[:,j] = op(tmp[:,j0:j1], axis=1)
     return out
 
+def dmul(A, B, out=None):
+    '''A * B'''
+    Aflat = A.reshape(-1)
+    Bflat = B.reshape(-1)
+    if out is None:
+        out = numpy.empty_like(Aflat)
+    else:
+        out = out.reshape(-1)
+    if Aflat.size != Bflat.size or Aflat.size != out.size:
+        raise ValueError(f'Incompatible sizes: {Aflat.size}, {Bflat.size} -> {out.size}')
+    if not Aflat.flags.contiguous or not Bflat.flags.contiguous or not out.flags.contiguous:
+        raise ValueError('Input arrays must be contiguous')
+    _np_helper.NPomp_dmul(Aflat.ctypes.data_as(ctypes.c_void_p),
+                          Bflat.ctypes.data_as(ctypes.c_void_p),
+                            out.ctypes.data_as(ctypes.c_void_p),
+                            ctypes.c_size_t(Aflat.size))
+    return out
+
 def expm(a):
     '''Equivalent to scipy.linalg.expm'''
     bs = [a.copy()]

--- a/pyscf/lib/pbc/cell.c
+++ b/pyscf/lib/pbc/cell.c
@@ -149,12 +149,12 @@ void get_Gv(double* Gv, double* rx, double* ry, double* rz, int* mesh, double* b
 void ewald_gs_nuc_grad(double* out, double* Gv, double* charges, double* coords,
                        double ew_eta, double weights, int natm, size_t ngrid)
 {
-    double *SI_real = (double*) malloc(natm*ngrid*sizeof(double));
-    double *SI_imag = (double*) malloc(natm*ngrid*sizeof(double)); 
+    double *SI_real = (double*) pyscf_malloc(natm*ngrid*sizeof(double));
+    double *SI_imag = (double*) pyscf_malloc(natm*ngrid*sizeof(double)); 
     get_SI_real_imag(SI_real, SI_imag, coords, Gv, natm, ngrid);
 
-    double *ZSI_real = calloc(ngrid, sizeof(double));
-    double *ZSI_imag = calloc(ngrid, sizeof(double));
+    double *ZSI_real = pyscf_calloc(ngrid, sizeof(double));
+    double *ZSI_imag = pyscf_calloc(ngrid, sizeof(double));
 
     NPdgemm('N', 'N', ngrid, 1, natm,
             ngrid, natm, ngrid, 0, 0, 0,
@@ -194,10 +194,10 @@ void ewald_gs_nuc_grad(double* out, double* Gv, double* charges, double* coords,
         }
     }
 }
-    free(SI_real);
-    free(SI_imag);
-    free(ZSI_real);
-    free(ZSI_imag);
+    pyscf_free(SI_real);
+    pyscf_free(SI_imag);
+    pyscf_free(ZSI_real);
+    pyscf_free(ZSI_imag);
 }
 
 

--- a/pyscf/lib/pbc/fft.h
+++ b/pyscf/lib/pbc/fft.h
@@ -18,6 +18,10 @@
 
 #include <fftw3.h>
 
+#ifdef PYSCF_USE_MKL
+#include "fftw3_mkl.h"
+#endif
+
 #define FFT_PLAN fftw_plan
 
 FFT_PLAN fft_create_r2c_plan(double* in, complex double* out, int rank, int* mesh);

--- a/pyscf/lib/pbc/fill_ints_sr.c
+++ b/pyscf/lib/pbc/fill_ints_sr.c
@@ -27,6 +27,10 @@
 #include "vhf/fblas.h"
 #include "np_helper/np_helper.h"
 
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
+
 #define INTBUFMAX       1000
 #define INTBUFMAX10     8000
 #define IMGBLK          80
@@ -247,7 +251,7 @@ void PBCsr2c_k_drv(int (*intor)(), void (*fill)(), double complex *out,
     const int jsh0 = shls_slice[2];
     const int jsh1 = shls_slice[3];
     const int njsh = jsh1 - jsh0;
-    double *expkL_r = malloc(sizeof(double) * nimgs*nkpts * OF_CMPLX);
+    double *expkL_r = pyscf_malloc(sizeof(double) * nimgs*nkpts * OF_CMPLX);
     double *expkL_i = expkL_r + nimgs*nkpts;
     int i;
     for (i = 0; i < nimgs*nkpts; i++) {
@@ -259,11 +263,14 @@ void PBCsr2c_k_drv(int (*intor)(), void (*fill)(), double complex *out,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
     int jsh;
-    double *env_loc = malloc(sizeof(double)*nenv);
+    double *env_loc = pyscf_malloc(sizeof(double)*nenv);
     NPdcopy(env_loc, env, nenv);
     size_t count = nkpts * OF_CMPLX + nimgs + 1;
-    double *buf = malloc(sizeof(double)*(count*INTBUFMAX10*comp+cache_size));
+    double *buf = pyscf_malloc(sizeof(double)*(count*INTBUFMAX10*comp+cache_size));
 #pragma omp for schedule(dynamic)
     for (jsh = 0; jsh < njsh; jsh++) {
         (*fill)(intor, out, nkpts, comp, nimgs, jsh,
@@ -271,10 +278,13 @@ void PBCsr2c_k_drv(int (*intor)(), void (*fill)(), double complex *out,
                 shls_slice, ao_loc, cintopt, refuniqshl_map, uniq_Rcut2s,
                 atm, natm, bas, nbas, env);
     }
-    free(buf);
-    free(env_loc);
+    pyscf_free(buf);
+    pyscf_free(env_loc);
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-    free(expkL_r);
+    pyscf_free(expkL_r);
 }
 
 // non-split basis implementation of j3c
@@ -535,10 +545,13 @@ void PBCsr3c_g_drv(int (*intor)(), void (*fill)(), double *out,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         int ish, jsh, ij;
-        double *env_loc = malloc(sizeof(double)*nenv);
+        double *env_loc = pyscf_malloc(sizeof(double)*nenv);
         memcpy(env_loc, env, sizeof(double)*nenv);
-        double *buf = malloc(sizeof(double)*(count+cache_size));
+        double *buf = pyscf_malloc(sizeof(double)*(count+cache_size));
 #pragma omp for schedule(dynamic)
         for (ij = 0; ij < nish*njsh; ij++) {
             ish = ij / njsh;
@@ -556,8 +569,11 @@ void PBCsr3c_g_drv(int (*intor)(), void (*fill)(), double *out,
                     uniq_Rcut2s, uniqshlpr_dij_loc,
                     atm, natm, bas, nbas, env);
         }
-        free(buf);
-        free(env_loc);
+        pyscf_free(buf);
+        pyscf_free(env_loc);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -950,7 +966,7 @@ void PBCsr3c_bvk_k_drv(int (*intor)(), void (*fill)(), double *out,
     const int nish = ish1 - ish0;
     const int njsh = jsh1 - jsh0;
 
-    double *expkL_r = malloc(sizeof(double) * bvk_nimgs*nkpts * OF_CMPLX);
+    double *expkL_r = pyscf_malloc(sizeof(double) * bvk_nimgs*nkpts * OF_CMPLX);
     double *expkL_i = expkL_r + bvk_nimgs*nkpts;
     int i;
     for (i = 0; i < bvk_nimgs*nkpts; i++) {
@@ -970,10 +986,13 @@ void PBCsr3c_bvk_k_drv(int (*intor)(), void (*fill)(), double *out,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
     int ish, jsh, ij;
-    double *env_loc = malloc(sizeof(double)*nenv);
+    double *env_loc = pyscf_malloc(sizeof(double)*nenv);
     memcpy(env_loc, env, sizeof(double)*nenv);
-    double *buf = malloc(sizeof(double)*(count+cache_size));
+    double *buf = pyscf_malloc(sizeof(double)*(count+cache_size));
 #pragma omp for schedule(dynamic)
     for (ij = 0; ij < nish*njsh; ij++) {
         ish = ij / njsh;
@@ -991,10 +1010,13 @@ void PBCsr3c_bvk_k_drv(int (*intor)(), void (*fill)(), double *out,
                 uniq_Rcut2s, uniqshlpr_dij_loc,
                 atm, natm, bas, nbas, env);
     }
-    free(buf);
-    free(env_loc);
+    pyscf_free(buf);
+    pyscf_free(env_loc);
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-    free(expkL_r);
+    pyscf_free(expkL_r);
 }
 
 // single k-point, no bvk
@@ -1208,7 +1230,7 @@ void PBCsr3c_k_drv(int (*intor)(), void (*fill)(), double *out,
     const int nish = ish1 - ish0;
     const int njsh = jsh1 - jsh0;
 
-    double *expkL_r = malloc(sizeof(double) * nimgs*nkpts * OF_CMPLX);
+    double *expkL_r = pyscf_malloc(sizeof(double) * nimgs*nkpts * OF_CMPLX);
     double *expkL_i = expkL_r + nimgs*nkpts;
     int i;
     for (i = 0; i < nimgs*nkpts; i++) {
@@ -1228,10 +1250,13 @@ void PBCsr3c_k_drv(int (*intor)(), void (*fill)(), double *out,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
     int ish, jsh, ij;
-    double *env_loc = malloc(sizeof(double)*nenv);
+    double *env_loc = pyscf_malloc(sizeof(double)*nenv);
     memcpy(env_loc, env, sizeof(double)*nenv);
-    double *buf = malloc(sizeof(double)*(count+cache_size));
+    double *buf = pyscf_malloc(sizeof(double)*(count+cache_size));
 #pragma omp for schedule(dynamic)
     for (ij = 0; ij < nish*njsh; ij++) {
         ish = ij / njsh;
@@ -1248,10 +1273,13 @@ void PBCsr3c_k_drv(int (*intor)(), void (*fill)(), double *out,
                 uniq_Rcut2s, uniqshlpr_dij_loc,
                 atm, natm, bas, nbas, env);
     }
-    free(buf);
-    free(env_loc);
+    pyscf_free(buf);
+    pyscf_free(env_loc);
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-    free(expkL_r);
+    pyscf_free(expkL_r);
 }
 
 // k-point pairs, bvk
@@ -1608,7 +1636,7 @@ void PBCsr3c_bvk_kk_drv(int (*intor)(), void (*fill)(), double *out,
     const int nish = ish1 - ish0;
     const int njsh = jsh1 - jsh0;
 
-    double *expkL_r = malloc(sizeof(double) * bvk_nimgs*nkpts * OF_CMPLX);
+    double *expkL_r = pyscf_malloc(sizeof(double) * bvk_nimgs*nkpts * OF_CMPLX);
     double *expkL_i = expkL_r + bvk_nimgs*nkpts;
     int i;
     for (i = 0; i < bvk_nimgs*nkpts; i++) {
@@ -1628,10 +1656,13 @@ void PBCsr3c_bvk_kk_drv(int (*intor)(), void (*fill)(), double *out,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
     int ish, jsh, ij;
-    double *env_loc = malloc(sizeof(double)*nenv);
+    double *env_loc = pyscf_malloc(sizeof(double)*nenv);
     memcpy(env_loc, env, sizeof(double)*nenv);
-    double *buf = malloc(sizeof(double)*(count+cache_size));
+    double *buf = pyscf_malloc(sizeof(double)*(count+cache_size));
 #pragma omp for schedule(dynamic)
     for (ij = 0; ij < nish*njsh; ij++) {
         ish = ij / njsh;
@@ -1649,10 +1680,13 @@ void PBCsr3c_bvk_kk_drv(int (*intor)(), void (*fill)(), double *out,
                 uniq_Rcut2s, uniqshlpr_dij_loc,
                 atm, natm, bas, nbas, env);
     }
-    free(buf);
-    free(env_loc);
+    pyscf_free(buf);
+    pyscf_free(env_loc);
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-    free(expkL_r);
+    pyscf_free(expkL_r);
 }
 
 // k-point pairs, no bvk
@@ -1877,7 +1911,7 @@ void PBCsr3c_kk_drv(int (*intor)(), void (*fill)(), double *out,
     const int nish = ish1 - ish0;
     const int njsh = jsh1 - jsh0;
 
-    double *expkL_r = malloc(sizeof(double) * nimgs*nkpts * OF_CMPLX);
+    double *expkL_r = pyscf_malloc(sizeof(double) * nimgs*nkpts * OF_CMPLX);
     double *expkL_i = expkL_r + nimgs*nkpts;
     int i;
     for (i = 0; i < nimgs*nkpts; i++) {
@@ -1897,10 +1931,13 @@ void PBCsr3c_kk_drv(int (*intor)(), void (*fill)(), double *out,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
     int ish, jsh, ij;
-    double *env_loc = malloc(sizeof(double)*nenv);
+    double *env_loc = pyscf_malloc(sizeof(double)*nenv);
     memcpy(env_loc, env, sizeof(double)*nenv);
-    double *buf = malloc(sizeof(double)*(count+cache_size));
+    double *buf = pyscf_malloc(sizeof(double)*(count+cache_size));
 #pragma omp for schedule(dynamic)
     for (ij = 0; ij < nish*njsh; ij++) {
         ish = ij / njsh;
@@ -1918,8 +1955,11 @@ void PBCsr3c_kk_drv(int (*intor)(), void (*fill)(), double *out,
                 uniq_Rcut2s, uniqshlpr_dij_loc,
                 atm, natm, bas, nbas, env);
     }
-    free(buf);
-    free(env_loc);
+    pyscf_free(buf);
+    pyscf_free(env_loc);
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
-    free(expkL_r);
+    pyscf_free(expkL_r);
 }

--- a/pyscf/lib/pbc/ft_ao.c
+++ b/pyscf/lib/pbc/ft_ao.c
@@ -663,7 +663,7 @@ void PBC_ft_bvk_drv(FPtrIntor intor, FPtr_eval_gz eval_gz, FPtrFill fill, FPtrSo
         PBCminimal_CINTEnvVars(&envs_cint, atm, natm, bas, nbas, env, NULL);
         int ish, jsh, ij;
         int cell0_shls[2];
-        double *buf = malloc(sizeof(double) * (buf_size+cache_size));
+        double *buf = pyscf_malloc(sizeof(double) * (buf_size+cache_size));
 #pragma omp for schedule(dynamic)
         for (ij = 0; ij < nish*njsh; ij++) {
                 ish = ij / njsh + ish0;
@@ -677,7 +677,7 @@ void PBC_ft_bvk_drv(FPtrIntor intor, FPtr_eval_gz eval_gz, FPtrFill fill, FPtrSo
                 (*fill)(intor, eval_gz, fsort, out, buf, cell0_shls,
                         &envs_cint, &envs_bvk);
         }
-        free(buf);
+        pyscf_free(buf);
 }
 }
 
@@ -790,8 +790,8 @@ void PBCsupmol_ovlp_mask(int8_t *out, double cutoff,
 {
         size_t Nbas = nbas;
         size_t Nbas1 = nbas + 1;
-        int *exps_group_loc = malloc(sizeof(int) * Nbas1);
-        double *exps = malloc(sizeof(double) * Nbas1 * 4);
+        int *exps_group_loc = pyscf_malloc(sizeof(int) * Nbas1);
+        double *exps = pyscf_malloc(sizeof(double) * Nbas1 * 4);
         double *rx = exps + Nbas1;
         double *ry = rx + Nbas1;
         double *rz = ry + Nbas1;
@@ -881,6 +881,6 @@ void PBCsupmol_ovlp_mask(int8_t *out, double cutoff,
                 }
         }
 }
-        free(exps);
-        free(exps_group_loc);
+        pyscf_free(exps);
+        pyscf_free(exps_group_loc);
 }

--- a/pyscf/lib/pbc/hf_grad.c
+++ b/pyscf/lib/pbc/hf_grad.c
@@ -57,7 +57,7 @@ void contract_vhf_dm(double* out, double* vhf, double* dm,
     if (thread_id == 0) {
         buf = out;
     } else {
-        buf = calloc(comp*natm, sizeof(double));
+        buf = pyscf_calloc(comp*natm, sizeof(double));
     }
     out_bufs[thread_id] = buf;
 
@@ -89,7 +89,7 @@ void contract_vhf_dm(double* out, double* vhf, double* dm,
 
     NPomp_dsum_reduce_inplace(out_bufs, comp*natm);
     if (thread_id != 0) {
-        free(buf);
+        pyscf_free(buf);
     }
 }
 }

--- a/pyscf/lib/pbc/hf_grad.c
+++ b/pyscf/lib/pbc/hf_grad.c
@@ -44,6 +44,10 @@ void contract_vhf_dm(double* out, double* vhf, double* dm,
 
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+    int save = mkl_set_num_threads_local(1);
+#endif
+
     size_t ij, ish, jsh, p0, q0;
     int ni, nj, i, ic, iatm, nimgs=1;
     NeighborList *nl0=NULL;
@@ -91,5 +95,9 @@ void contract_vhf_dm(double* out, double* vhf, double* dm,
     if (thread_id != 0) {
         pyscf_free(buf);
     }
+
+#ifdef PYSCF_USE_MKL
+    mkl_set_num_threads_local(save);
+#endif
 }
 }

--- a/pyscf/lib/pbc/inner_dot.c
+++ b/pyscf/lib/pbc/inner_dot.c
@@ -21,6 +21,10 @@
 #include "vhf/fblas.h"
 #include "np_helper/np_helper.h"
 
+#ifdef PYSCF_USE_MKL
+#include "mkl.h"
+#endif
+
 #define GSIZE           104
 #define BLKSIZE         18
 
@@ -175,6 +179,9 @@ void PBC_ddot_CNC_s1(double *outR, double *aR, double *bR, double *cR,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         char TRANS_T = 'T';
         char TRANS_N = 'N';
         double D1 = 1;
@@ -182,7 +189,7 @@ void PBC_ddot_CNC_s1(double *outR, double *aR, double *bR, double *cR,
         int i0, i1, j0, j1, ig0, ig1;
         int i, j, ig, da, dg, dab;
         size_t nbc = nb * nc;
-        double *bufR = malloc(sizeof(double) * BLKSIZE * nb * GSIZE);
+        double *bufR = pyscf_malloc(sizeof(double) * BLKSIZE * nb * GSIZE);
         double *pbufR;
 #pragma omp for schedule(static)
         for (i0 = 0; i0 < na; i0 += BLKSIZE) { i1 = MIN(i0+BLKSIZE, na);
@@ -206,7 +213,10 @@ void PBC_ddot_CNC_s1(double *outR, double *aR, double *bR, double *cR,
                                &D1, outR+i0*nbc, &nc);
                 }
         }
-        free(bufR);
+        pyscf_free(bufR);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -218,6 +228,9 @@ void PBC_zdot_CNC_s1(double *outR, double *outI, double *aR, double *aI,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         char TRANS_T = 'T';
         char TRANS_N = 'N';
         double D1 = 1;
@@ -226,7 +239,7 @@ void PBC_zdot_CNC_s1(double *outR, double *outI, double *aR, double *aI,
         int i0, i1, j0, j1, ig0, ig1;
         int i, j, ig, da, dg, dab;
         size_t nbc = nb * nc;
-        double *bufR = malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
+        double *bufR = pyscf_malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
         double *bufI = bufR + BLKSIZE * nb * GSIZE;
         double *poutR, *poutI, *pbufR, *pbufI;
 #pragma omp for schedule(static)
@@ -261,7 +274,10 @@ void PBC_zdot_CNC_s1(double *outR, double *outI, double *aR, double *aI,
                                &ND1, cI+ig0, &ng, bufR, &gsize, &D1, outI, &nc);
                 }
         }
-        free(bufR);
+        pyscf_free(bufR);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -276,6 +292,9 @@ void PBC_kzdot_CNC_s1(double *outR, double *outI,
         int ntasks = nblocks_a * nkptij;
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         char TRANS_T = 'T';
         char TRANS_N = 'N';
         double D1 = 1;
@@ -286,7 +305,7 @@ void PBC_kzdot_CNC_s1(double *outR, double *outI,
         int i, j, ig, i0, i1, j0, j1, ig0, ig1;
         int it, kk_idx, ki, kj, da, dg, dab;
         double *aR, *aI, *bR, *bI;
-        double *bufR = malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
+        double *bufR = pyscf_malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
         double *bufI = bufR + BLKSIZE * nb * GSIZE;
         double *poutR, *poutI, *pbufR, *pbufI;
 #pragma omp for schedule(static)
@@ -332,7 +351,10 @@ void PBC_kzdot_CNC_s1(double *outR, double *outI,
                         }
                 }
         }
-        free(bufR);
+        pyscf_free(bufR);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -344,6 +366,9 @@ void PBC_zdot_CNN_s1(double *outR, double *outI, double *aR, double *aI,
 {
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         char TRANS_T = 'T';
         char TRANS_N = 'N';
         double D1 = 1;
@@ -352,7 +377,7 @@ void PBC_zdot_CNN_s1(double *outR, double *outI, double *aR, double *aI,
         int i0, i1, j0, j1, ig0, ig1;
         int i, j, ig, da, dg, dab;
         size_t nbc = nb * nc;
-        double *bufR = malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
+        double *bufR = pyscf_malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
         double *bufI = bufR + BLKSIZE * nb * GSIZE;
         double *poutR, *poutI, *pbufR, *pbufI;
 #pragma omp for schedule(static)
@@ -387,7 +412,10 @@ void PBC_zdot_CNN_s1(double *outR, double *outI, double *aR, double *aI,
                                &D1, cI+ig0, &ng, bufR, &gsize, &D1, outI, &nc);
                 }
         }
-        free(bufR);
+        pyscf_free(bufR);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -402,6 +430,9 @@ void PBC_kzdot_CNN_s1(double *outR, double *outI,
         int ntasks = nblocks_a * nkptij;
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         char TRANS_T = 'T';
         char TRANS_N = 'N';
         double D1 = 1;
@@ -412,7 +443,7 @@ void PBC_kzdot_CNN_s1(double *outR, double *outI,
         int i, j, ig, i0, i1, j0, j1, ig0, ig1;
         int it, kk_idx, ki, kj, da, dg, dab;
         double *aR, *aI, *bR, *bI;
-        double *bufR = malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
+        double *bufR = pyscf_malloc(sizeof(double) * BLKSIZE * nb * GSIZE * 2);
         double *bufI = bufR + BLKSIZE * nb * GSIZE;
         double *poutR, *poutI, *pbufR, *pbufI;
 #pragma omp for schedule(static)
@@ -458,7 +489,10 @@ void PBC_kzdot_CNN_s1(double *outR, double *outI,
                         }
                 }
         }
-        free(bufR);
+        pyscf_free(bufR);
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -472,17 +506,20 @@ void PBC_kcontract(double *vkR, double *vkI, double *dmR, double *dmI,
 {
         size_t nao2 = nao * nao;
         size_t size_vk = n_dm * nkpts * nao2;
-        double *vtmpR = calloc(sizeof(double), size_vk*2);
+        double *vtmpR = pyscf_calloc(sizeof(double), size_vk*2);
         double *vtmpI = vtmpR + size_vk;
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         char TRANS_T = 'T';
         char TRANS_N = 'N';
         double D1 = 1.;
         double D0 = 0.;
         double N1 = -1.;
         size_t Naog = nao * ngrids;
-        double *pLqR = malloc(sizeof(double) * BLEN * nao2 * 4);
+        double *pLqR = pyscf_malloc(sizeof(double) * BLEN * nao2 * 4);
         double *pLqI = pLqR + BLEN * nao2;
         double *bufR = pLqI + BLEN * nao2;
         double *bufI = bufR + BLEN * nao2;
@@ -570,15 +607,18 @@ dgemm_(&TRANS_N, &TRANS_T, &nao, &nao, &nm, &N1, bufR, &nao, pLqI, &nao, &D1, vI
                         }
                 }
         }
-        free(pLqR);
+        pyscf_free(pLqR);
 #pragma omp barrier
 #pragma omp for schedule(static)
         for (i = 0; i < size_vk; i++) {
                 vkR[i] += vtmpR[i];
                 vkI[i] += vtmpI[i];
         }
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(vtmpR);
+        pyscf_free(vtmpR);
 }
 
 #define BLEN    24
@@ -592,17 +632,20 @@ void PBC_kcontract_dmf(double *vkR, double *vkI, double *moR, double *moI,
         size_t nao2 = nao * nao;
         size_t naoo = nao * nocc;
         size_t size_vk = n_dm * nkpts * nao2;
-        double *vtmpR = calloc(sizeof(double), size_vk*2);
+        double *vtmpR = pyscf_calloc(sizeof(double), size_vk*2);
         double *vtmpI = vtmpR + size_vk;
 #pragma omp parallel
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
         char TRANS_T = 'T';
         char TRANS_N = 'N';
         double D1 = 1.;
         double D0 = 0.;
         double N1 = -1.;
         size_t Naog = nao * ngrids;
-        double *pLqR = malloc(sizeof(double) * BLEN * (nao2*2+naoo*4));
+        double *pLqR = pyscf_malloc(sizeof(double) * BLEN * (nao2*2+naoo*4));
         double *pLqI = pLqR + BLEN * nao2;
         double *bufR = pLqI + BLEN * nao2;
         double *bufI = bufR + BLEN * naoo;
@@ -689,13 +732,16 @@ dgemm_(&TRANS_N, &TRANS_T, &nao, &nao, &go, &N1, buf1R, &nao, bufI, &nao, &D1, v
                         }
                 }
         }
-        free(pLqR);
+        pyscf_free(pLqR);
 #pragma omp barrier
 #pragma omp for schedule(static)
         for (i = 0; i < size_vk; i++) {
                 vkR[i] += vtmpR[i];
                 vkI[i] += vtmpI[i];
         }
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
-        free(vtmpR);
+        pyscf_free(vtmpR);
 }

--- a/pyscf/lib/pbc/neighbor_list.c
+++ b/pyscf/lib/pbc/neighbor_list.c
@@ -21,17 +21,18 @@
 #include "config.h"
 #include "cint.h"
 #include "pbc/neighbor_list.h"
+#include "np_helper/np_helper.h"
 
 #define SQUARE(r)       (r[0]*r[0]+r[1]*r[1]+r[2]*r[2])
 
 void init_neighbor_pair(NeighborPair** np, int nimgs, int* Ls_list)
 {
-    NeighborPair *np0 = (NeighborPair*) malloc(sizeof(NeighborPair));
+    NeighborPair *np0 = (NeighborPair*) pyscf_malloc(sizeof(NeighborPair));
     np0->nimgs = nimgs;
     np0->q_cond = NULL;
     np0->center = NULL;
     if (nimgs > 0){
-        np0->Ls_list = (int*) malloc(sizeof(int)*nimgs);
+        np0->Ls_list = (int*) pyscf_malloc(sizeof(int)*nimgs);
         int i;
         for (i=0; i<nimgs; i++) {
             np0->Ls_list[i] = Ls_list[i];
@@ -50,25 +51,25 @@ void del_neighbor_pair(NeighborPair** np)
         return;
     }
     if (np0->Ls_list) {
-        free(np0->Ls_list);
+        pyscf_free(np0->Ls_list);
     }
     if (np0->q_cond) {
-        free(np0->q_cond);
+        pyscf_free(np0->q_cond);
     }
     if (np0->center) {
-        free(np0->center);
+        pyscf_free(np0->center);
     }
-    free(np0);
+    pyscf_free(np0);
     *np = NULL;
 }
 
 void init_neighbor_list(NeighborList** nl, int nish, int njsh, int nimgs)
 {
-    NeighborList *nl0 = (NeighborList*) malloc(sizeof(NeighborList)); 
+    NeighborList *nl0 = (NeighborList*) pyscf_malloc(sizeof(NeighborList)); 
     nl0->nish = nish;
     nl0->njsh = njsh;
     nl0->nimgs = nimgs;
-    nl0->pairs = (NeighborPair**) malloc(sizeof(NeighborPair*)*nish*njsh);
+    nl0->pairs = (NeighborPair**) pyscf_malloc(sizeof(NeighborPair*)*nish*njsh);
     int ish, jsh;
     for (ish=0; ish<nish; ish++)
         for (jsh=0; jsh<njsh; jsh++) {
@@ -87,7 +88,7 @@ void build_neighbor_list(NeighborList** nl,
 
 #pragma omp parallel
 {
-    int *buf = (int*) malloc(sizeof(int)*nimgs);
+    int *buf = (int*) pyscf_malloc(sizeof(int)*nimgs);
     int ish, jsh, iL, nL;
     int ish_atm_id, jsh_atm_id;
     double ish_radius, jsh_radius, rmax, dij;
@@ -123,7 +124,7 @@ void build_neighbor_list(NeighborList** nl,
             init_neighbor_pair(np, nL, buf);
         }
     }
-    free(buf);
+    pyscf_free(buf);
 }
 }
 
@@ -142,9 +143,9 @@ void del_neighbor_list(NeighborList** nl)
                 del_neighbor_pair(nl0->pairs + ish*njsh+jsh);
             }
         }
-        free(nl0->pairs);
+        pyscf_free(nl0->pairs);
     }
-    free(nl0);
+    pyscf_free(nl0);
     *nl = NULL;
 }
 
@@ -167,7 +168,7 @@ int NLOpt_screen(int* shls, NeighborListOpt* opt)
 
 void NLOpt_init(NeighborListOpt **opt)
 {
-    NeighborListOpt *opt0 = malloc(sizeof(NeighborListOpt));
+    NeighborListOpt *opt0 = pyscf_malloc(sizeof(NeighborListOpt));
     opt0->nl = NULL;
     opt0->fprescreen = &NLOpt_noscreen;
     *opt = opt0;
@@ -179,7 +180,7 @@ void NLOpt_del(NeighborListOpt **opt)
     if (!opt0) {
         return;
     }
-    free(opt0);
+    pyscf_free(opt0);
     *opt = NULL;
 }
 

--- a/pyscf/lib/pbc/optimizer.c
+++ b/pyscf/lib/pbc/optimizer.c
@@ -20,13 +20,14 @@
 #include <math.h>
 #include "cint.h"
 #include "pbc/optimizer.h"
+#include "np_helper/np_helper.h"
 
 #define SQUARE(r)       (r[0]*r[0]+r[1]*r[1]+r[2]*r[2])
 
 void PBCinit_optimizer(PBCOpt **opt, int *atm, int natm,
                         int *bas, int nbas, double *env)
 {
-        PBCOpt *opt0 = malloc(sizeof(PBCOpt));
+        PBCOpt *opt0 = pyscf_malloc(sizeof(PBCOpt));
         opt0->rrcut = NULL;
         opt0->rcut = NULL;
         opt0->fprescreen = &PBCnoscreen;
@@ -41,12 +42,12 @@ void PBCdel_optimizer(PBCOpt **opt)
         }
 
         if (opt0->rrcut != NULL) {
-                free(opt0->rrcut);
+                pyscf_free(opt0->rrcut);
         }
         if (!opt0->rcut) {
-                free(opt0->rcut);
+                pyscf_free(opt0->rcut);
         }
-        free(opt0);
+        pyscf_free(opt0);
         *opt = NULL;
 }
 
@@ -93,9 +94,9 @@ void PBCset_rcut_cond(PBCOpt *opt, double *rcut,
                       int *atm, int natm, int *bas, int nbas, double *env)
 {
         if (opt->rrcut != NULL) {
-                free(opt->rrcut);
+                pyscf_free(opt->rrcut);
         }
-        opt->rrcut = (double *)malloc(sizeof(double) * nbas);
+        opt->rrcut = (double *)pyscf_malloc(sizeof(double) * nbas);
         opt->fprescreen = &PBCrcut_screen;
 
         int i;
@@ -108,9 +109,9 @@ void PBCset_rcut_cond_loose(PBCOpt *opt, double *rcut,
                             int *atm, int natm, int *bas, int nbas, double *env)
 {
         if (opt->rcut != NULL) {
-                free(opt->rcut);
+                pyscf_free(opt->rcut);
         }
-        opt->rcut = (double *)malloc(sizeof(double) * nbas);
+        opt->rcut = (double *)pyscf_malloc(sizeof(double) * nbas);
         opt->fprescreen = &PBCrcut_screen_loose;
 
         int i;

--- a/pyscf/lib/ri/r_df_incore.c
+++ b/pyscf/lib/ri/r_df_incore.c
@@ -127,7 +127,7 @@ int RIhalfmmm_r_s2_ket(double complex *vout, double complex *vin,
         int j_start = envs->ket_start;
         int j_count = envs->ket_count;
         double complex *mo_coeff = envs->mo_coeff;
-        double complex *buf = malloc(sizeof(double complex)*n2c*j_count);
+        double complex *buf = pyscf_malloc(sizeof(double complex)*n2c*j_count);
         int i, j;
 
         zhemm_(&SIDE_L, &UPLO_U, &n2c, &j_count,
@@ -139,7 +139,7 @@ int RIhalfmmm_r_s2_ket(double complex *vout, double complex *vin,
                 }
                 vout += j_count;
         }
-        free(buf);
+        pyscf_free(buf);
         return 0;
 }
 
@@ -210,9 +210,9 @@ void RItranse2_r_s2(int (*fmmm)(),
         int nao = envs->nao;
         size_t ij_pair = (*fmmm)(NULL, NULL, envs, 1);
         size_t nao2 = nao*(nao+1)/2;
-        double complex *buf = malloc(sizeof(double complex) * nao*nao);
+        double complex *buf = pyscf_malloc(sizeof(double complex) * nao*nao);
         NPzunpack_tril(nao, vin+nao2*row_id, buf, 0);
         (*fmmm)(vout+ij_pair*row_id, buf, envs, 0);
-        free(buf);
+        pyscf_free(buf);
 }
 

--- a/pyscf/lib/vhf/fill_nr_s8.c
+++ b/pyscf/lib/vhf/fill_nr_s8.c
@@ -25,6 +25,7 @@
 #include "nr_direct.h"
 #include "optimizer.h"
 #include "gto/gto.h"
+#include "np_helper/np_helper.h"
 
 #define MAX(I,J)        ((I) > (J) ? (I) : (J))
 
@@ -124,14 +125,14 @@ void GTO2e_cart_or_sph(int (*intor)(), CINTOpt *cintopt, double *eri, int *ao_lo
 #pragma omp parallel
 {
         int i, j, ij;
-        double *buf = malloc(sizeof(double) * (di*di*nao*nao + cache_size));
+        double *buf = pyscf_malloc(sizeof(double) * (di*di*nao*nao + cache_size));
 #pragma omp for nowait schedule(dynamic, 2)
         for (ij = 0; ij < nbas*(nbas+1)/2; ij++) {
                 i = (int)(sqrt(2*ij+.25) - .5 + 1e-7);
                 j = ij - (i*(i+1)/2);
                 store_ij(intor, eri, buf, i, j, vhfopt, &envs);
         }
-        free(buf);
+        pyscf_free(buf);
 }
         CVHFdel_optimizer(&vhfopt);
 }

--- a/pyscf/lib/vhf/hessian_screen.c
+++ b/pyscf/lib/vhf/hessian_screen.c
@@ -78,17 +78,21 @@ void CVHFnr_int2e_pp_q_cond(int (*intor)(), CINTOpt *cintopt, double *q_cond,
 #pragma omp parallel \
         shared(intor, cintopt, ao_loc, atm, natm, bas, nbas, env)
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         double qtmp;
         int i, j, iijj, di, dj, ish, jsh;
         size_t ij;
         int shls[4];
-        double *cache = malloc(sizeof(double) * cache_size);
+        double *cache = pyscf_malloc(sizeof(double) * cache_size);
         di = 0;
         for (ish = 0; ish < nbas; ish++) {
                 dj = ao_loc[ish+1] - ao_loc[ish];
                 di = MAX(di, dj);
         }
-        double *buf = malloc(sizeof(double) * 9 * di*di*di*di);
+        double *buf = pyscf_malloc(sizeof(double) * 9 * di*di*di*di);
         double *bufx = buf;
         double *bufy, *bufz;
 #pragma omp for schedule(dynamic, 4)
@@ -117,8 +121,12 @@ void CVHFnr_int2e_pp_q_cond(int (*intor)(), CINTOpt *cintopt, double *q_cond,
                 }
                 q_cond[ish*nbas+jsh] = qtmp;
         }
-        free(buf);
-        free(cache);
+        pyscf_free(buf);
+        pyscf_free(cache);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -127,13 +135,13 @@ void CVHFgrad_jk_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                             int *bas, int nbas, double *env)
 {
         if (opt->q_cond != NULL) {
-                free(opt->q_cond);
+                pyscf_free(opt->q_cond);
         }
         nbas = opt->nbas;
         size_t Nbas = nbas;
         size_t Nbas2 = Nbas * Nbas;
         // First n*n elements for derivatives, the next n*n elements for regular ERIs
-        opt->q_cond = (double *)malloc(sizeof(double) * Nbas2*2);
+        opt->q_cond = (double *)pyscf_malloc(sizeof(double) * Nbas2*2);
 
         if (ao_loc[nbas] == CINTtot_cgto_spheric(bas, nbas)) {
                 CVHFnr_int2e_q_cond(int2e_sph, NULL, opt->q_cond+Nbas2, ao_loc,
@@ -150,10 +158,10 @@ void CVHFgrad_jk_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
                                int *atm, int natm, int *bas, int nbas, double *env)
 {
         if (opt->dm_cond != NULL) {
-                free(opt->dm_cond);
+                pyscf_free(opt->dm_cond);
         }
         nbas = opt->nbas;
-        opt->dm_cond = (double *)malloc(sizeof(double) * nbas*nbas);
+        opt->dm_cond = (double *)pyscf_malloc(sizeof(double) * nbas*nbas);
         CVHFnr_dm_cond1(opt->dm_cond, dm, nset, ao_loc, atm, natm, bas, nbas, env);
 }
 
@@ -246,17 +254,21 @@ void CVHFnr_int2e_pppp_q_cond(int (*intor)(), CINTOpt *cintopt, double *q_cond,
 #pragma omp parallel \
         shared(intor, cintopt, ao_loc, atm, natm, bas, nbas, env)
 {
+#ifdef PYSCF_USE_MKL
+        int save = mkl_set_num_threads_local(1);
+#endif
+
         double qtmp;
         int i, j, iijj, di, dj, ish, jsh;
         size_t ij;
         int shls[4];
-        double *cache = malloc(sizeof(double) * cache_size);
+        double *cache = pyscf_malloc(sizeof(double) * cache_size);
         di = 0;
         for (ish = 0; ish < nbas; ish++) {
                 dj = ao_loc[ish+1] - ao_loc[ish];
                 di = MAX(di, dj);
         }
-        double *buf = malloc(sizeof(double) * 256 * di*di*di*di);
+        double *buf = pyscf_malloc(sizeof(double) * 256 * di*di*di*di);
         double *bufxx = buf;
         double *bufxy, *bufxz, *bufyx, *bufyy, *bufyz, *bufzx, *bufzy, *bufzz;
 #pragma omp for schedule(dynamic, 4)
@@ -298,8 +310,12 @@ void CVHFnr_int2e_pppp_q_cond(int (*intor)(), CINTOpt *cintopt, double *q_cond,
                 }
                 q_cond[ish*nbas+jsh] = qtmp;
         }
-        free(buf);
-        free(cache);
+        pyscf_free(buf);
+        pyscf_free(cache);
+
+#ifdef PYSCF_USE_MKL
+        mkl_set_num_threads_local(save);
+#endif
 }
 }
 
@@ -308,13 +324,13 @@ void CVHFipip1_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                           int *bas, int nbas, double *env)
 {
         if (opt->q_cond != NULL) {
-                free(opt->q_cond);
+                pyscf_free(opt->q_cond);
         }
         nbas = opt->nbas;
         size_t Nbas = nbas;
         size_t Nbas2 = Nbas * Nbas;
         // First n*n elements for derivatives, the next n*n elements for regular ERIs
-        opt->q_cond = (double *)malloc(sizeof(double) * nbas*nbas*2);
+        opt->q_cond = (double *)pyscf_malloc(sizeof(double) * nbas*nbas*2);
 
         if (ao_loc[nbas] == CINTtot_cgto_spheric(bas, nbas)) {
                 CVHFnr_int2e_q_cond(int2e_sph, NULL, opt->q_cond+Nbas2, ao_loc,

--- a/pyscf/lib/vhf/nr_incore.c
+++ b/pyscf/lib/vhf/nr_incore.c
@@ -627,11 +627,15 @@ void CVHFnrs8_incore_drv(double *eri, double **dms, double **vjk,
 #pragma omp parallel default(none) \
         shared(eri, dms, vjk, n_dm, nao, fjk)
         {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
+
                 int i, j, ic;
                 size_t ij, off;
                 size_t npair = nao*(nao+1)/2;
                 size_t nn = nao * nao;
-                double *v_priv = calloc(nn*n_dm, sizeof(double));
+                double *v_priv = pyscf_calloc(nn*n_dm, sizeof(double));
                 FjkPtr pf;
                 double *pv;
 #pragma omp for nowait schedule(dynamic, 4)
@@ -654,7 +658,11 @@ void CVHFnrs8_incore_drv(double *eri, double **dms, double **vjk,
                                 }
                         }
                 }
-                free(v_priv);
+                pyscf_free(v_priv);
+
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
         }
 }
 
@@ -664,11 +672,15 @@ void CVHFnrs4_incore_drv(double *eri, double **dms, double **vjk,
 #pragma omp parallel default(none) \
         shared(eri, dms, vjk, n_dm, nao, fjk)
         {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
+
                 int i, j, ic;
                 size_t ij, off;
                 size_t npair = nao*(nao+1)/2;
                 size_t nn = nao * nao;
-                double *v_priv = calloc(nn*n_dm, sizeof(double));
+                double *v_priv = pyscf_calloc(nn*n_dm, sizeof(double));
                 FjkPtr pf;
                 double *pv;
 #pragma omp for nowait schedule(dynamic, 4)
@@ -691,7 +703,11 @@ void CVHFnrs4_incore_drv(double *eri, double **dms, double **vjk,
                                 }
                         }
                 }
-                free(v_priv);
+                pyscf_free(v_priv);
+
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
         }
 }
 
@@ -701,11 +717,15 @@ void CVHFnrs2ij_incore_drv(double *eri, double **dms, double **vjk,
 #pragma omp parallel default(none) \
         shared(eri, dms, vjk, n_dm, nao, fjk)
         {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
+
                 int i, j, ic;
                 size_t ij, off;
                 size_t npair = nao*(nao+1)/2;
                 size_t nn = nao * nao;
-                double *v_priv = calloc(nn*n_dm, sizeof(double));
+                double *v_priv = pyscf_calloc(nn*n_dm, sizeof(double));
                 FjkPtr pf;
                 double *pv;
 #pragma omp for nowait schedule(dynamic, 4)
@@ -728,7 +748,11 @@ void CVHFnrs2ij_incore_drv(double *eri, double **dms, double **vjk,
                                 }
                         }
                 }
-                free(v_priv);
+                pyscf_free(v_priv);
+
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
         }
 }
 
@@ -738,11 +762,15 @@ void CVHFnrs2kl_incore_drv(double *eri, double **dms, double **vjk,
 #pragma omp parallel default(none) \
         shared(eri, dms, vjk, n_dm, nao, fjk)
         {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
+
                 int i, j, ic;
                 size_t ij, off;
                 size_t npair = nao*(nao+1)/2;
                 size_t nn = nao * nao;
-                double *v_priv = calloc(nn*n_dm, sizeof(double));
+                double *v_priv = pyscf_calloc(nn*n_dm, sizeof(double));
                 FjkPtr pf;
                 double *pv;
 #pragma omp for nowait schedule(dynamic, 4)
@@ -765,7 +793,11 @@ void CVHFnrs2kl_incore_drv(double *eri, double **dms, double **vjk,
                                 }
                         }
                 }
-                free(v_priv);
+                pyscf_free(v_priv);
+
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
         }
 }
 
@@ -775,10 +807,14 @@ void CVHFnrs1_incore_drv(double *eri, double **dms, double **vjk,
 #pragma omp parallel default(none) \
         shared(eri, dms, vjk, n_dm, nao, fjk)
         {
+#ifdef PYSCF_USE_MKL
+                int save = mkl_set_num_threads_local(1);
+#endif
+
                 int i, j, ic;
                 size_t ij, off;
                 size_t nn = nao * nao;
-                double *v_priv = calloc(nn*n_dm, sizeof(double));
+                double *v_priv = pyscf_calloc(nn*n_dm, sizeof(double));
                 FjkPtr pf;
                 double *pv;
 #pragma omp for nowait schedule(dynamic, 4)
@@ -801,6 +837,10 @@ void CVHFnrs1_incore_drv(double *eri, double **dms, double **vjk,
                                 }
                         }
                 }
-                free(v_priv);
+                pyscf_free(v_priv);
+
+#ifdef PYSCF_USE_MKL
+                mkl_set_num_threads_local(save);
+#endif
         }
 }


### PR DESCRIPTION
A large number of PySCF users also use Intel MKL, since x64 is probably still the most common architecture in academic clusters. This PR allows PySCF to make use of MKL-specific BLAS extensions and other convenient functions when MKL is used.

As a result, MKL's fine-grained threading control API is exposed. This allows MKL to be set to sequential mode whenever MKL/blas/lapack functions are invoked within an OpenMP parallel region, while MKL is multithreaded outside of such regions.

A side benefit is that, if an MKL-variant PySCF conda package is built, PySCF will be able to retain control over the number of threads used for BLAS. Effectively, conda-installed PySCF with libblas=mkl links to the Intel MKL Single Dynamic Library, which is multithreaded by default. (Performance is still quite good in this case and one can always use the `OMP_NESTED` and `MKL_THREADING_LAYER` environment variables to prevent oversubscription, if it ever occurs.)
